### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: Run Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ushkinaz/cbn-guide/security/code-scanning/1](https://github.com/ushkinaz/cbn-guide/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow. This can be placed at the workflow root (applies to all jobs unless overridden) or at the job level (applies only to the named job). Since this workflow does not require write access to repository contents or metadata in any of its steps, specifying the minimal permission (`contents: read`) will suffice and follows the principle of least privilege. Edit the workflow file `.github/workflows/ci.yml` and add the following block near the top, preferably immediately after the `name` key:

```yaml
permissions:
  contents: read
```

This requires no new imports, methods, or package dependencies.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
