### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete regular expression for hostnames

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -63,7 +63,7 @@ export default defineConfig({
           },
           {
             // Use saved translations if possible, update in the background.
-            urlPattern: /^https:\/\/cds.svc.transifex.net\//,
+            urlPattern: /^https:\/\/cds\.svc\.transifex\.net\//,
             handler: "StaleWhileRevalidate",
           },
         ],


### PR DESCRIPTION
Potential fix for [https://github.com/ushkinaz/cbn-guide/security/code-scanning/2](https://github.com/ushkinaz/cbn-guide/security/code-scanning/2)

To fix the problem, we need to escape all unescaped `.` in the hostname part of the regular expression so that it only matches a literal dot, not any character. Specifically, on line 66, change `.svc.transifex.net` to `\.svc\.transifex\.net`. This will make the caching rule precisely recognize URLs for the intended host. Only edit the regular expression pattern on line 66 within vite.config.ts. No additional imports or variable/method definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
