### PR TITLE
fix(spawnLocations): update getTerrainForMapgen to count fill_ter tiles when rows are missing using mapgensize or default to 1x1

### DIFF
--- a/src/types/item/spawnLocations.test.ts
+++ b/src/types/item/spawnLocations.test.ts
@@ -5,6 +5,7 @@ import {
   collection,
   getFurnitureForMapgen,
   getLootForMapgen,
+  getTerrainForMapgen,
   parseItemGroup,
   parsePalette,
   repeatChance,
@@ -426,6 +427,39 @@ describe("loot", () => {
     //   e.v. for one chance = 75% * 2/3 = 0.5
     //   4x 0.5 = 2
     expect(loot.get("item_b")!.expected.toFixed(2)).toEqual("2.00");
+  });
+});
+
+describe("terrain", () => {
+  it("fills with fill_ter when rows are missing", () => {
+    const data = new CBNData([
+      {
+        type: "mapgen",
+        method: "json",
+        om_terrain: "test_ter",
+        object: {
+          fill_ter: "t_floor",
+        },
+      } as Mapgen,
+    ]);
+    const loot = getTerrainForMapgen(data, data.byType("mapgen")[0]);
+    expect(loot.get("t_floor")).toEqual({ prob: 1, expected: 1 * 1 });
+  });
+
+  it("uses mapgensize when rows are missing", () => {
+    const data = new CBNData([
+      {
+        type: "mapgen",
+        method: "json",
+        om_terrain: "test_ter",
+        object: {
+          fill_ter: "t_floor",
+          mapgensize: [12, 12],
+        },
+      } as Mapgen,
+    ]);
+    const loot = getTerrainForMapgen(data, data.byType("mapgen")[0]);
+    expect(loot.get("t_floor")).toEqual({ prob: 1, expected: 12 * 12 });
   });
 });
 

--- a/src/types/item/spawnLocations.ts
+++ b/src/types/item/spawnLocations.ts
@@ -677,6 +677,7 @@ export function getTerrainForMapgen(data: CBNData, mapgen: raw.Mapgen): Loot {
   if (terrainForMapgenCache.has(mapgen))
     return terrainForMapgenCache.get(mapgen)!;
   const palette = parseTerrainPalette(data, mapgen.object);
+  const rows = mapgen.object.rows ?? [];
   const fill_ter = mapgen.object.fill_ter
     ? getMapgenValueDistribution(mapgen.object.fill_ter)
     : new Map<string, number>();
@@ -686,11 +687,15 @@ export function getTerrainForMapgen(data: CBNData, mapgen: raw.Mapgen): Loot {
   const additional_items = collection([...place_terrain]);
   const countByPalette = new Map<string, number>();
   let fillCount = 0;
-  for (const row of mapgen.object.rows ?? [])
+  for (const row of rows)
     for (const char of row)
       if (palette.has(char))
         countByPalette.set(char, (countByPalette.get(char) ?? 0) + 1);
       else fillCount += 1;
+  if (rows.length === 0) {
+    const [width, height] = mapgen.object.mapgensize ?? [1, 1];
+    fillCount = width * height;
+  }
   const items: Loot[] = [];
   for (const [sym, count] of countByPalette.entries()) {
     const loot = palette.get(sym)!;


### PR DESCRIPTION
# fill_ter missing when rows are absent

- Severity: Medium
- Complexity: Low

## Summary

`getTerrainForMapgen` counts `fill_ter` tiles only for characters not covered by a palette symbol in `rows`. For mapgens that define `fill_ter` but omit `rows`, `fillCount` stays 0 and the fill terrain is dropped entirely.

## Where

- `src/types/item/spawnLocations.ts:688-710` → `fillCount` increments only while iterating `rows`; if `rows` is empty/undefined, no fill tiles are emitted.
- Real data: 31 om_terrains with `fill_ter` and no `rows` (e.g., `lake_surface` → `t_water_dp`, `river_center` → `t_water_moving_dp`, `open_air_blimp` → `t_open_air`, `special_field`, `special_forest`, `island_forest`, etc.) in `_test/all.test.json`.

## Reproduction

1. Minimal script mirroring `lake_surface`:

   ```ts
   import { CBNData } from "../src/data";
   import { getTerrainForMapgen } from "../src/types/item/spawnLocations";

   const data = new CBNData([
     {
       type: "mapgen",
       method: "json",
       om_terrain: "lake_surface",
       object: { fill_ter: "t_water_dp", rows: [] },
     },
   ]);

   const loot = getTerrainForMapgen(data, data.byType("mapgen")[0]);
   // Actual: empty Map; Expected: 24*24 tiles of t_water_dp.
   ```

2. Actual: no terrain returned when `rows` is empty.
3. Expected: `fill_ter` should populate the full mapgen area even without `rows`.

## Impact

- Terrain summaries for many outdoor/air/water OMTs show nothing, severely misrepresenting those tiles.

## TDD ideas

- Add a vitest case with `fill_ter` and no `rows`, asserting the expected count matches the mapgen size (default 24×24 when unspecified).
- Add a case where `mapgensize` is custom (e.g., 12×12) to ensure counts use the explicit size when rows are absent.
