### PR TITLE
fix(spawnLocations): fix loot aggregation for deeply nested mapgen chains by replacing recursion depth limit with cycle detection using WeakSet stack

### DIFF
--- a/src/types/item/spawnLocations.test.ts
+++ b/src/types/item/spawnLocations.test.ts
@@ -639,6 +639,32 @@ describe("nested mapgen", () => {
 
   it.todo("handles repeat range");
 
+  it("handles deep nested chains", async () => {
+    const chain = Array.from(
+      { length: 5 },
+      (_, i) =>
+        ({
+          type: "mapgen",
+          method: "json",
+          ...(i === 0
+            ? { om_terrain: "test_ter" }
+            : { nested_mapgen_id: `mg${i}` }),
+          object: {
+            mapgensize: [1, 1],
+            rows: ["X"],
+            ...(i < 4
+              ? { place_nested: [{ x: 0, y: 0, chunks: [`mg${i + 1}`] }] }
+              : { item: { X: { item: "deep_item" } } }),
+          },
+        }) as Mapgen,
+    );
+    const data = new CBNData(chain);
+    const loot = await getLootForMapgen(data, data.byType("mapgen")[0]);
+    expect([...loot.entries()]).toEqual([
+      ["deep_item", { prob: 1, expected: 1 }],
+    ]);
+  });
+
   it("reads nested", async () => {
     const data = new CBNData([
       {

--- a/src/types/item/spawnLocations.ts
+++ b/src/types/item/spawnLocations.ts
@@ -553,10 +553,8 @@ function resolveNestedChunks(
 function lootForChunks(
   data: CBNData,
   chunks: (raw.MapgenValue | [raw.MapgenValue, number])[],
+  stack: WeakSet<raw.Mapgen>,
 ): Loot {
-  onStack += 1;
-  // TODO: See https://github.com/nornagon/cdda-guide/issues/73
-  if (onStack > 4) return new Map();
   const normalizedChunks = (chunks ?? []).map((c) =>
     Array.isArray(c) && c.length === 2 && typeof c[1] === "number"
       ? (c as [raw.MapgenValue, number])
@@ -570,7 +568,7 @@ function lootForChunks(
         : [];
       const loot = mergeLoot(
         chunkMapgens.map((mg) => {
-          const loot = getLootForMapgen(data, mg);
+          const loot = getLootForMapgenInternal(data, mg, stack);
           const weight = mg.weight ?? 1000;
           return { loot, weight };
         }),
@@ -578,14 +576,23 @@ function lootForChunks(
       return { loot, weight };
     }),
   );
-  onStack -= 1;
   return loot;
 }
 
 const lootForMapgenCache = new WeakMap<raw.Mapgen, Loot>();
 export function getLootForMapgen(data: CBNData, mapgen: raw.Mapgen): Loot {
+  return getLootForMapgenInternal(data, mapgen, new WeakSet());
+}
+
+function getLootForMapgenInternal(
+  data: CBNData,
+  mapgen: raw.Mapgen,
+  stack: WeakSet<raw.Mapgen>,
+): Loot {
   if (lootForMapgenCache.has(mapgen)) return lootForMapgenCache.get(mapgen)!;
-  const palette = parsePalette(data, mapgen.object);
+  if (stack.has(mapgen)) return new Map();
+  stack.add(mapgen);
+  const palette = parsePalette(data, mapgen.object, stack);
   const mappingPalette = parseMappingItems(data, mapgen.object.mapping);
   const place_items: Loot[] = (mapgen.object.place_items ?? []).map(
     ({ item, chance = 100, repeat }) =>
@@ -620,7 +627,7 @@ export function getLootForMapgen(data: CBNData, mapgen: raw.Mapgen): Loot {
           : new Map<string, ItemChance>(),
   );
   const place_nested = (mapgen.object.place_nested ?? []).map((nested) => {
-    const loot = lootForChunks(data, resolveNestedChunks(nested));
+    const loot = lootForChunks(data, resolveNestedChunks(nested), stack);
     const multipliedLoot: Loot = new Map();
     for (const [id, chance] of loot.entries()) {
       multipliedLoot.set(
@@ -645,6 +652,7 @@ export function getLootForMapgen(data: CBNData, mapgen: raw.Mapgen): Loot {
   ]);
   loot.delete("null");
   lootForMapgenCache.set(mapgen, loot);
+  stack.delete(mapgen);
   return loot;
 }
 
@@ -897,8 +905,10 @@ const paletteCache = new WeakMap<raw.PaletteData, Map<string, Loot>>();
 export function parsePalette(
   data: CBNData,
   palette: raw.PaletteData,
+  stack?: WeakSet<raw.Mapgen>,
 ): Map<string, Loot> {
   if (paletteCache.has(palette)) return paletteCache.get(palette)!;
+  const stackLocal = stack ?? new WeakSet<raw.Mapgen>();
   const sealed_item = parsePlaceMapping(
     palette.sealed_item,
     function* ({ item, items, chance = 100 }) {
@@ -946,11 +956,11 @@ export function parsePalette(
     },
   );
   const nested = parsePlaceMapping(palette.nested, function* (nestedEntry) {
-    yield lootForChunks(data, resolveNestedChunks(nestedEntry));
+    yield lootForChunks(data, resolveNestedChunks(nestedEntry), stackLocal);
   });
   const palettes = (palette.palettes ?? []).flatMap((val) => {
     if (typeof val === "string") {
-      return [parsePalette(data, data.byId("palette", val))];
+      return [parsePalette(data, data.byId("palette", val), stackLocal)];
     } else if ("distribution" in val) {
       const opts = val.distribution;
       function prob<T>(it: T | [T, number]) {
@@ -962,7 +972,7 @@ export function parsePalette(
       const totalProb = opts.reduce((m, it) => m + prob(it), 0);
       return opts.map((it) =>
         attenuatePalette(
-          parsePalette(data, data.byId("palette", id(it))),
+          parsePalette(data, data.byId("palette", id(it)), stackLocal),
           prob(it) / totalProb,
         ),
       );
@@ -979,7 +989,7 @@ export function parsePalette(
         const id = getMapgenValueDistribution(param.default);
         return [...id.entries()].map(([id, chance]) =>
           attenuatePalette(
-            parsePalette(data, data.byId("palette", id)),
+            parsePalette(data, data.byId("palette", id), stackLocal),
             chance,
           ),
         );


### PR DESCRIPTION
# Nested mapgen recursion cut off at depth 4 drops loot

- Severity: Medium-High
- Complexity: Medium

## Summary
`lootForChunks` bails out when the recursion depth exceeds 4 (`onStack > 4` returns an empty `Map`). Real mapgen chains go at least 5 levels deep; anything deeper than 4 silently loses all loot instead of being aggregated.

## Where
- `src/types/item/spawnLocations.ts:539-568` → depth guard `if (onStack > 4) return new Map();`
- Real data: `_test/all.test.json` contains nested mapgens with a longest chain depth of 5; the deepest chain is rooted at `nested_mapgen_id` `lab_spawn_7x7_wall_nw` (found via script calculating max nested depth).

## Reproduction
1. Craft nested mapgens five levels deep and call `getLootForMapgen` on the top level:
   ```ts
   import { CBNData } from "../src/data";
   import { getLootForMapgen } from "../src/types/item/spawnLocations";

   const chain = Array.from({ length: 5 }, (_, i) => ({
     type: "mapgen",
     method: "json",
     nested_mapgen_id: `mg${i}`,
     object: {
       mapgensize: [1, 1],
       place_nested: i === 4 ? [] : [{ x: 0, y: 0, chunks: [`mg${i + 1}`] }],
       item: i === 4 ? { X: { item: "deep_item" } } : undefined,
       rows: ["X"],
     },
   }));

   const data = new CBNData(chain);
   const loot = getLootForMapgen(data, data.byId("mapgen", "mg0"));
   // Actual: returns empty; expected: includes deep_item.
   ```
2. Actual: once `onStack` hits 5, the deepest mapgen returns empty, so loot from level 4+ is dropped.
3. Expected: recursion should permit at least the maximum depth present in data (>=5) and aggregate loot from all nested levels.

## Impact
- Loot coming from deeply nested chunks (e.g., lab wall spawns) is completely omitted, giving misleading probabilities or empty results.

## TDD ideas
- Add a vitest that builds a five-level nested chain and asserts the deepest item appears with probability 1.
- Optionally parameterize the depth limit (or remove it) and test that a cycle guard still prevents infinite recursion for self-referential chunks.
