### PR TITLE
fix: include "set" placements for furniture and terrain in loot calculations and tests to ensure they are processed correctly

### DIFF
--- a/src/types/item/spawnLocations.test.ts
+++ b/src/types/item/spawnLocations.test.ts
@@ -5,8 +5,8 @@ import {
   collection,
   getFurnitureForMapgen,
   getLootForMapgen,
-  lootForOmSpecial,
   getTerrainForMapgen,
+  lootForOmSpecial,
   parseItemGroup,
   parsePalette,
   repeatChance,
@@ -810,5 +810,61 @@ describe("mapping", () => {
     const loot = getTerrainForMapgen(data, data.byType("mapgen")[0]);
     expect(loot.get("t_rock")).toEqual({ prob: 1, expected: 1 });
     expect(loot.get("t_floor")).toEqual({ prob: 1, expected: 1 });
+  });
+
+  it("set furniture", async () => {
+    const data = new CBNData([
+      {
+        type: "mapgen",
+        method: "json",
+        om_terrain: "test_ter",
+        object: {
+          rows: [],
+          set: [
+            {
+              point: "furniture",
+              id: "f_test_furn",
+              x: [1, 22],
+              y: [1, 22],
+              chance: 50,
+              repeat: [2, 4],
+            },
+          ],
+        },
+      } as Mapgen,
+    ]);
+    const loot = getFurnitureForMapgen(data, data.byType("mapgen")[0]);
+    const entry = loot.get("f_test_furn")!;
+    expect(entry.prob).toBeCloseTo(0.8541667, 5);
+    expect(entry.expected).toBeCloseTo(1.5, 5);
+  });
+});
+
+describe("terrain", () => {
+  it("set terrain", async () => {
+    const data = new CBNData([
+      {
+        type: "mapgen",
+        method: "json",
+        om_terrain: "test_ter",
+        object: {
+          rows: [],
+          set: [
+            {
+              point: "terrain",
+              id: "t_test_ter",
+              x: [0, 23],
+              y: [0, 23],
+              chance: 25,
+              repeat: [1, 3],
+            },
+          ],
+        },
+      } as Mapgen,
+    ]);
+    const loot = getTerrainForMapgen(data, data.byType("mapgen")[0]);
+    const entry = loot.get("t_test_ter")!;
+    expect(entry.prob).toBeCloseTo(0.421875, 5);
+    expect(entry.expected).toBeCloseTo(0.5, 5);
   });
 });


### PR DESCRIPTION
# `set`-based furniture/terrain placements are ignored

- Severity: Medium
- Complexity: Medium-High

## Summary
`getFurnitureForMapgen` and `getTerrainForMapgen` do not read `object.set`, so any furniture/terrain spawned via set instructions never appears in the computed loot/placement results. This drops both deterministic and probabilistic placements that aren’t covered by palettes or place_*.

## Where
- `src/types/item/spawnLocations.ts` never touches `mapgen.object.set` in furniture/terrain flows.
- Real data in `_test/all.test.json`:
  - Furniture sets: 38 occurrences (e.g., `pond_swamp`, `natural_spring`, `garage_gas_*`, `clear_furniture`) place boulders, cattails, rubble, or flowers via `set`.
  - Terrain sets: ~300 occurrences (e.g., `bandit_garage_1`, `dirtplaza_aban1`, `forest_aban1`) use `set` for terrain/trap/line/square placements.

## Reproduction
1. Minimal example mirroring common data:
   ```ts
   import { CBNData } from "../src/data";
   import { getFurnitureForMapgen, getTerrainForMapgen } from "../src/types/item/spawnLocations";

   const data = new CBNData([
     {
       type: "mapgen",
       method: "json",
       om_terrain: "pond_swamp",
       object: {
         mapgensize: [24, 24],
         rows: [], // set-only spawn
         set: [
           { point: "furniture", id: "f_boulder_small", x: [1, 22], y: [1, 22], chance: 9, repeat: [1, 5] },
           { point: "terrain", id: "t_dirt", x: [0, 23], y: [0, 23] },
         ],
       },
     },
   ]);

   getFurnitureForMapgen(data, data.byType("mapgen")[0]); // Actual: empty
   getTerrainForMapgen(data, data.byType("mapgen")[0]);   // Actual: empty
   ```
2. Actual: both getters return empty maps because `set` is ignored.
3. Expected: placements from `set` should be counted, respecting chance/repeat ranges.

## Impact
- Surfaces water/pond/road/lab variants with no furniture/terrain when they actually place many objects via `set`, misleading users about what spawns where.

## TDD ideas
- Add vitest cases for both furniture and terrain that build a mapgen using `set` (with repeat/chance) and assert counts/probabilities are reflected in the returned maps.
- Include a case with no `rows` (set-only mapgen) to ensure fill/sets are processed even without palette symbols.
