### PR TITLE
fix(types): #20 support mapping for items, furniture, and terrain in mapgen and update loot calculations to include mapping entries

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1134,7 +1134,7 @@ export interface MapgenObject {
   //liquids?: LiquidsClass;
   //place_liquids?: PlaceLiquid[];
   rotation?: [number, number] | [number] | number;
-  mapping?: any; // TODO:
+  mapping?: Record<string, MapgenMapping>;
   //place_fields?: PlaceField[];
   //fields?: Fields;
   //vendingmachines?: { [key: string]: Vendingmachine };
@@ -1255,8 +1255,8 @@ type MapgenParameter = {
 export interface MapgenMapping {
   items?: MapgenItemGroup | MapgenItemGroup[];
   item?: MapgenSpawnItem | MapgenSpawnItem[];
-  //furniture?: string;
-  //terrain?: string;
+  furniture?: MapgenValue;
+  terrain?: MapgenValue;
   //traps?: string;
   //fields?: Fields;
 }

--- a/src/types/item/spawnLocations.test.ts
+++ b/src/types/item/spawnLocations.test.ts
@@ -728,3 +728,67 @@ describe("furniture", () => {
     expect(loot.get("f_test_furn")?.expected).toBeCloseTo(17.5);
   });
 });
+
+describe("mapping", () => {
+  it("includes mapping items", () => {
+    const data = new CBNData([
+      {
+        type: "mapgen",
+        method: "json",
+        om_terrain: "test_ter",
+        object: {
+          rows: ["X"],
+          mapping: {
+            X: { items: { item: "test_group" } },
+          },
+        },
+      } as Mapgen,
+      {
+        type: "item_group",
+        id: "test_group",
+        subtype: "collection",
+        items: ["item_a"],
+      } as ItemGroupData,
+    ]);
+    const loot = getLootForMapgen(data, data.byType("mapgen")[0]);
+    expect(loot.get("item_a")).toEqual({ prob: 1, expected: 1 });
+  });
+
+  it("includes mapping furniture", () => {
+    const data = new CBNData([
+      {
+        type: "mapgen",
+        method: "json",
+        om_terrain: "test_ter",
+        object: {
+          rows: ["X"],
+          mapping: {
+            X: { furniture: "f_test_furn" },
+          },
+        },
+      } as Mapgen,
+    ]);
+    const loot = getFurnitureForMapgen(data, data.byType("mapgen")[0]);
+    expect(loot.get("f_test_furn")).toEqual({ prob: 1, expected: 1 });
+  });
+
+  it("includes mapping terrain and respects fill_ter", () => {
+    const data = new CBNData([
+      {
+        type: "mapgen",
+        method: "json",
+        om_terrain: "test_ter",
+        object: {
+          fill_ter: "t_floor",
+          rows: ["X."],
+          mapping: {
+            X: { terrain: "t_rock" },
+          },
+        },
+      } as Mapgen,
+    ]);
+    const loot = getTerrainForMapgen(data, data.byType("mapgen")[0]);
+    expect(loot.get("t_rock")).toEqual({ prob: 1, expected: 1 });
+    expect(loot.get("t_floor")).toEqual({ prob: 1, expected: 1 });
+  });
+});


### PR DESCRIPTION
Fixes  #30 


Changes:

- Added parsing for mapgen object mapping entries (items, furniture, terrain) and merged them into loot/furniture/terrain computations, including correct fill_ter handling when mapping defines terrain.
- Expanded mapgen mapping types to include terrain/furniture and added helper utilities to count symbol occurrences and apply repeat scaling.
- Added vitest coverage for mapping-driven items, furniture, and terrain, including fill_ter interaction.

Tests:

- yarn vitest src/types/item/spawnLocations.test.ts
- yarn verify:format
