### PR TITLE
Fix: Chance over 100 produces invalid probability

### DIFF
--- a/src/types/item/spawnLocations.test.ts
+++ b/src/types/item/spawnLocations.test.ts
@@ -1203,3 +1203,26 @@ describe("parameters", () => {
     expect(loot.get("t_dirt")!.prob).toBeCloseTo(0.2);
   });
 });
+
+describe("chance > 100", () => {
+  it("handles chance > 100 in place_loot", async () => {
+    const data = new CBNData([
+      {
+        type: "mapgen",
+        method: "json",
+        om_terrain: "test_ter",
+        object: {
+          rows: [],
+          place_loot: [{ item: "test_item", x: 0, y: 0, chance: 150 }],
+        },
+      } as Mapgen,
+    ]);
+    const loot = getLootForMapgen(data, data.byType("mapgen")[0]);
+    const entry = loot.get("test_item")!;
+    // prob should be capped at 1.0
+    expect(entry.prob).toBeLessThanOrEqual(1.0);
+    expect(entry.prob).toBeCloseTo(1.0);
+    // expected should reflect the actual average count (1.5)
+    expect(entry.expected).toBeCloseTo(1.5);
+  });
+});

--- a/src/types/item/spawnLocations.ts
+++ b/src/types/item/spawnLocations.ts
@@ -102,6 +102,19 @@ function scaleItemChance(a: ItemChance, t: number): ItemChance {
   };
 }
 
+/**
+ * Convert a chance percentage (0-100+) to ItemChance.
+ * Probability is capped at 1.0: chance > 100 means "higher expected count",
+ * not "more than 100% probability".
+ */
+function chanceToItemChance(chance: number): ItemChance {
+  const p = chance / 100;
+  return {
+    prob: Math.min(1.0, p),
+    expected: p,
+  };
+}
+
 function averageMapgenInt(
   v: undefined | number | [number] | [number, number],
 ): number {
@@ -748,7 +761,7 @@ function getLootForMapgenInternal(
           [
             v.item,
             repeatItemChance(
-              { prob: chance / 100, expected: chance / 100 },
+              chanceToItemChance(chance),
               normalizeMinMax(v.repeat),
             ),
           ],


### PR DESCRIPTION
## Summary

`chance` values greater than 100 are treated as probabilities > 1, producing invalid probabilities and expected values.

## Context

Some mapgen entries use `chance > 100`, which should be interpreted as multiple rolls or clamped.

## Impact

End users see probabilities exceeding 100% and misleading expected counts.

## Technical Details

`chance` is divided by 100 directly, and `repeatChance` assumes `0 <= chance <= 1`. No clamping or multi-roll handling is applied.

## Examples

- `data/json/mapgen/park.json#L241-L310`:
  - `{ "item": "feces_dog", "chance": 200 }` in `place_item`.

## Acceptance Criteria

- Probabilities are never greater than 1.0 in the UI.
- `chance > 100` is interpreted consistently (clamped or treated as multiple rolls), matching player expectations.

Fixes #38