### PR TITLE
Fix: fill_ter count incorrect when rows missing

### DIFF
--- a/src/types/item/spawnLocations.test.ts
+++ b/src/types/item/spawnLocations.test.ts
@@ -552,7 +552,7 @@ describe("terrain", () => {
       } as Mapgen,
     ]);
     const loot = getTerrainForMapgen(data, data.byType("mapgen")[0]);
-    expect(loot.get("t_floor")).toEqual({ prob: 1, expected: 1 * 1 });
+    expect(loot.get("t_floor")).toEqual({ prob: 1, expected: 1 * 1 * 24 * 24 });
   });
 
   it("uses mapgensize when rows are missing", () => {
@@ -568,7 +568,10 @@ describe("terrain", () => {
       } as Mapgen,
     ]);
     const loot = getTerrainForMapgen(data, data.byType("mapgen")[0]);
-    expect(loot.get("t_floor")).toEqual({ prob: 1, expected: 12 * 12 });
+    expect(loot.get("t_floor")).toEqual({
+      prob: 1,
+      expected: 12 * 12 * 24 * 24,
+    });
   });
 });
 
@@ -981,6 +984,23 @@ describe("terrain", () => {
     const entry = loot.get("t_test_ter")!;
     expect(entry.prob).toBeCloseTo(0.421875, 5);
     expect(entry.expected).toBeCloseTo(0.5, 5);
+  });
+
+  it("counts fill_ter correctly when rows are missing", () => {
+    const data = new CBNData([
+      {
+        type: "mapgen",
+        method: "json",
+        om_terrain: "test_ter",
+        object: {
+          fill_ter: "t_dirt",
+        },
+      } as any,
+    ]);
+    const loot = getTerrainForMapgen(data, data.byType("mapgen")[0]);
+    const entry = loot.get("t_dirt")!;
+    // 1x1 submap = 24x24 = 576 tiles
+    expect(entry.expected).toBe(576);
   });
 
   it("treats conditional nested chunks as conditional (averages chunks and else_chunks)", async () => {

--- a/src/types/item/spawnLocations.ts
+++ b/src/types/item/spawnLocations.ts
@@ -811,7 +811,7 @@ export function getTerrainForMapgen(data: CBNData, mapgen: raw.Mapgen): Loot {
       else fillCount += 1;
   if (rows.length === 0) {
     const [width, height] = mapgen.object.mapgensize ?? [1, 1];
-    fillCount = width * height;
+    fillCount = width * height * 24 * 24;
   }
   const items: Loot[] = [
     ...lootFromCounts(countByPalette, palette),


### PR DESCRIPTION
## Summary

When `rows` are missing, `fill_ter` is counted as a 1×1 area instead of a full 24×24 submap, undercounting terrain.

## Context

Some mapgens omit `rows` and rely on `fill_ter` for the entire submap.

## Impact

End users see drastically reduced terrain counts and probabilities for mapgens without `rows`.

## Technical Details

`getTerrainForMapgen` sets `fillCount = width * height` when `rows` is empty, but these are mapgen sizes in submaps, not tiles. It should multiply by 24×24 per submap.

## Examples

- `data/json/mapgen/dummy/dummy.json#L2-L8`:
  - `{ "fill_ter": "t_dirt" }` with no `rows`.
  - Current logic counts 1 tile instead of 576 tiles.

## Acceptance Criteria

- Terrain fill counts match the full submap area when `rows` are absent.
- End users see reasonable terrain frequency for fill-only mapgens.

Fixes #39