### PR TITLE
Fix failing search and routing tests

### DIFF
--- a/src/routing.test.ts
+++ b/src/routing.test.ts
@@ -19,7 +19,7 @@ const testBuilds = JSON.parse(
 );
 
 describe("Routing E2E Tests", () => {
-  vi.setConfig({ testTimeout: 10000 });
+  vi.setConfig({ testTimeout: 30000 });
   let originalFetch: typeof global.fetch;
   let container: HTMLElement;
 

--- a/src/search.test.ts
+++ b/src/search.test.ts
@@ -7,6 +7,7 @@ import { cleanup, render } from "@testing-library/svelte";
 import { CBNData } from "./data";
 
 import SearchResults from "./SearchResults.svelte";
+import { syncSearch } from "./search";
 
 let data: CBNData = new CBNData([
   { type: "MONSTER", id: "zombie", name: "zombie", symbol: "Z" },
@@ -18,6 +19,7 @@ let data: CBNData = new CBNData([
 afterEach(cleanup);
 
 test("search results shows results", () => {
+  syncSearch("zombie", data);
   const { container } = render(SearchResults, { data, search: "zombie" });
   expect(container.textContent).not.toMatch(/undefined|NaN|object Object/);
   expect(container.textContent).toMatch(/zombie/);
@@ -27,12 +29,14 @@ test("search results shows results", () => {
 });
 
 test("search with <2 letters shows ...", () => {
+  syncSearch("z", data);
   const { container } = render(SearchResults, { data, search: "z" });
   expect(container.textContent).not.toMatch(/undefined|NaN|object Object/);
   expect(container.textContent).toMatch(/\.\.\./);
 });
 
 test("search with no results shows 'no results'", () => {
+  syncSearch("zaoeusthhhahchsigdiypcgiybx", data);
   const { container } = render(SearchResults, {
     data,
     search: "zaoeusthhhahchsigdiypcgiybx",


### PR DESCRIPTION
Fix failing tests in `src/search.test.ts` and `src/routing.test.ts`.

1.  **`src/search.test.ts`**: The `SearchResults` component depends on the `searchResults` Svelte store, which is updated by the `syncSearch` function. The test was rendering the component without populating this store, causing assertions to fail. The fix involves manually calling `syncSearch` with the test data before verifying the rendered output.
2.  **`src/routing.test.ts`**: The E2E tests for routing are comprehensive and can be slow. The existing timeout of 10 seconds was insufficient, causing intermittent timeouts. The timeout has been increased to 30 seconds to accommodate the execution time of these tests.

---
*PR created automatically by Jules for task [14687447117210016347](https://jules.google.com/task/14687447117210016347) started by @ushkinaz*