### PR TITLE
⚡ Optimize Catalog filtering and fix empty group headers

### DIFF
--- a/src/Catalog.svelte
+++ b/src/Catalog.svelte
@@ -22,9 +22,17 @@ export let data: CBNData;
 let typeWithCorrectType = type as keyof SupportedTypesWithMapped;
 setContext("data", data);
 
+const groupFilter = ({
+  mutation: (m: Mutation) =>
+    !/Fake\d$/.test(m.id) &&
+    !m.types?.includes("BACKGROUND_OTHER_SURVIVORS_STORY") &&
+    !m.types?.includes("BACKGROUND_SURVIVAL_STORY"),
+}[type] ?? (() => true)) as (t: SupportedTypeMapped) => boolean;
+
 const things = data
   .byType(type as keyof SupportedTypesWithMapped)
   .filter((o) => "id" in o && o.id)
+  .filter(groupFilter)
   .sort(byName);
 
 // Ref https://github.com/CleverRaven/Cataclysm-DDA/blob/658bbe419fb652086fd4d46bf5bbf9e137228464/src/item_factory.cpp#L4774
@@ -62,13 +70,6 @@ const groups = groupBy(
   groupingFn as (t: SupportedTypeMapped) => string[],
 );
 const groupsList = [...groups.entries()].sort(([a], [b]) => a.localeCompare(b));
-
-const groupFilter = ({
-  mutation: (m: Mutation) =>
-    !/Fake\d$/.test(m.id) &&
-    !m.types?.includes("BACKGROUND_OTHER_SURVIVORS_STORY") &&
-    !m.types?.includes("BACKGROUND_SURVIVAL_STORY"),
-}[type] ?? (() => true)) as (t: SupportedTypeMapped) => boolean;
 </script>
 
 <h1 class="capitalize">{t(plural(type))}</h1>
@@ -83,7 +84,7 @@ const groupFilter = ({
         <h1>{groupName}</h1>
       {/if}
       <LimitedList
-        items={group.filter(groupFilter)}
+        items={group}
         let:item
         limit={groupsList.length === 1 ? Infinity : 10}>
         {#if (type === "overmap_special" || type === "city_building") && item.subtype !== "mutable"}

--- a/src/Catalog.test.ts
+++ b/src/Catalog.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { render } from "@testing-library/svelte";
+import { describe, it, expect, vi } from "vitest";
+import Catalog from "./Catalog.svelte";
+import { CBNData } from "./data";
+
+// Mock transifex/native
+vi.mock("@transifex/native", () => ({
+  t: (str: string, params: any) => {
+    let res = str;
+    if (params) {
+      for (const k in params) {
+        res = res.replace(`{${k}}`, params[k]);
+      }
+    }
+    return res;
+  },
+  tx: {
+    init: () => {},
+    setCurrentLocale: () => {},
+  },
+}));
+
+// Mock i18n
+vi.mock("./i18n", () => ({
+  t: (str: string) => str,
+}));
+
+describe("Catalog Optimization", () => {
+  it("filters mutations correctly and hides empty groups", () => {
+    // We create data where 'Fake1' is filtered out.
+    // 'Cat1' has only 'Fake1'.
+    // 'Cat2' has 'Valid1'.
+    const data = new CBNData([
+      {
+        type: "mutation",
+        id: "Fake1",
+        name: "Fake Mutation",
+        category: ["Cat1"],
+      },
+      {
+        type: "mutation",
+        id: "Valid1",
+        name: "Valid Mutation",
+        category: ["Cat2"],
+      },
+      // We do NOT define mutation_category objects for Cat1/Cat2 so they fall back to generic list view
+    ]);
+
+    const { getByText, queryByText } = render(Catalog, {
+      type: "mutation",
+      data,
+    });
+
+    // Valid mutation should be present
+    expect(getByText("Valid Mutation")).toBeTruthy();
+
+    // Fake mutation should be filtered out
+    expect(queryByText("Fake Mutation")).toBeNull();
+
+    // Category 2 header should be present
+    expect(getByText("Cat2")).toBeTruthy();
+
+    // Category 1 header:
+    // With optimization (filtering before grouping), it SHOULD NOT show up because it only contains filtered items.
+    expect(queryByText("Cat1")).toBeNull();
+  });
+});


### PR DESCRIPTION
Optimized `src/Catalog.svelte` by moving the item filtering logic from the template to the script section. This ensures filtering happens only once during initialization rather than on every render. This change also fixes a visual bug where category headers were displayed even when all items within the category were filtered out (e.g., hidden internal mutations). Added a regression test `src/Catalog.test.ts` to verify the fix and ensure correct filtering behavior.

---
*PR created automatically by Jules for task [6356188241051343792](https://jules.google.com/task/6356188241051343792) started by @ushkinaz*