### PR TITLE
🎨 Palette: Improve JsonView accessibility and add Copy button

### DIFF
--- a/.agent/palette.md
+++ b/.agent/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-18 - Accessibility of JSON Views
+**Learning:** Developer-focused tools (like "Raw JSON" toggles) often miss basic accessibility attributes like `aria-expanded`, but they are just as important for screen reader users who might be developers.
+**Action:** Always audit `aria-expanded` and keyboard accessibility for disclosure widgets, even in "technical" parts of the UI.

--- a/src/JsonView.test.ts
+++ b/src/JsonView.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { expect, test, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+import JsonView from "./JsonView.svelte";
+
+test("JsonView has accessible toggle button and copy functionality", async () => {
+  const obj = { id: "test", type: "item" };
+  const writeText = vi.fn();
+
+  // Mock clipboard
+  Object.assign(navigator, {
+    clipboard: {
+      writeText,
+    },
+  });
+
+  const { getByText, getByRole, queryByText } = render(JsonView, {
+    obj,
+    buildNumber: "123",
+  });
+
+  const button = getByRole("button", { name: /Raw JSON/ });
+
+  // Verify aria-expanded is false initially
+  expect(button.getAttribute("aria-expanded")).toBe("false");
+
+  // Copy button should not be visible yet
+  expect(queryByText("Copy")).toBeNull();
+
+  // Click to expand
+  await fireEvent.click(button);
+
+  // Verify aria-expanded is true
+  expect(button.getAttribute("aria-expanded")).toBe("true");
+
+  // Content should be visible
+  expect(getByText(/"id": "test"/)).toBeTruthy();
+
+  // Copy button should be visible
+  const copyButton = getByText("Copy");
+  expect(copyButton).toBeTruthy();
+
+  // Click copy
+  await fireEvent.click(copyButton);
+
+  // Verify clipboard write
+  expect(writeText).toHaveBeenCalledWith(JSON.stringify(obj, null, 2));
+
+  // Verify feedback
+  expect(getByText("Copied!")).toBeTruthy();
+});


### PR DESCRIPTION
💡 What: Improved the `JsonView` component by adding `aria-expanded` attributes and a "Copy" button to copy the raw JSON to the clipboard.
🎯 Why: Screen reader users couldn't tell if the JSON view was expanded or collapsed. Developers/users needed an easy way to extract the JSON data for debugging or reporting issues.
📸 Before/After: Added "Copy" button and accessible attributes.
♿ Accessibility: Added `aria-expanded` to toggle button and `aria-hidden` to decorative icon. Ensure "Copy" button is keyboard accessible.

---
*PR created automatically by Jules for task [5635796416210280642](https://jules.google.com/task/5635796416210280642) started by @ushkinaz*