### PR TITLE
refactor(ui): use semantic lists for comma/and-separated skill displays

### DIFF
--- a/src/types/Construction.svelte
+++ b/src/types/Construction.svelte
@@ -52,9 +52,11 @@ if (construction.pre_flags)
   <dl>
     <dt>{t("Required Skills")}</dt>
     <dd>
-      {#each construction.required_skills ?? [] as [id, level], i}
-        <ItemLink type="skill" {id} showIcon={false} /> ({level}){#if i + 2 === construction.required_skills?.length}{" and "}{:else if i + 1 !== construction.required_skills?.length}{", "}{/if}
-      {/each}
+      <ul class="comma-separated and">
+        {#each construction.required_skills ?? [] as [id, level]}
+          <li><ItemLink type="skill" {id} showIcon={false} /> ({level})</li>
+        {/each}
+      </ul>
     </dd>
     <dt>{t("Time", { _context })}</dt>
     <dd>

--- a/src/types/Fault.svelte
+++ b/src/types/Fault.svelte
@@ -84,11 +84,15 @@ const fault_flag_descriptions: Record<string, string> = {
     <dl>
       <dt>{t("Skills Used", { _context })}</dt>
       <dd>
-        {#each mending_method.skills as { id, level }, i}
-          <ItemLink type="skill" {id} showIcon={false} /> ({level}){#if i === mending_method.skills.length - 2}{" and "}{:else if i !== mending_method.skills.length - 1}{", "}{/if}
+        {#if mending_method.skills.length}
+          <ul class="comma-separated and">
+            {#each mending_method.skills as { id, level }}
+              <li><ItemLink type="skill" {id} showIcon={false} /> ({level})</li>
+            {/each}
+          </ul>
         {:else}
           {t("none")}
-        {/each}
+        {/if}
       </dd>
       <dt>{t("Time to Complete")}</dt>
       <dd>{mending_method.time}</dd>

--- a/src/types/MartialArtRequirements.svelte
+++ b/src/types/MartialArtRequirements.svelte
@@ -18,11 +18,15 @@ const requiredBuffs =
 
 <dt>{t("Required Skills")}</dt>
 <dd>
-  {#each item.skill_requirements ?? [] as { name, level }, i}
-    <ItemLink type="skill" id={name} showIcon={false} /> ({level}){#if i + 2 === item.skill_requirements?.length}{" and "}{:else if i + 1 !== item.skill_requirements?.length}{", "}{/if}
+  {#if item.skill_requirements?.length}
+    <ul class="comma-separated and">
+      {#each item.skill_requirements ?? [] as { name, level }}
+        <li><ItemLink type="skill" id={name} showIcon={false} /> ({level})</li>
+      {/each}
+    </ul>
   {:else}
     <em>{t("none")}</em>
-  {/each}
+  {/if}
 </dd>
 {#if requiredBuffs.length}
   <dt>{t("Required Buffs", { _context })}</dt>

--- a/src/types/Recipe.svelte
+++ b/src/types/Recipe.svelte
@@ -99,11 +99,13 @@ function activityLevelName(level: number) {
     {#if skillsRequired.length}
       <dt>{t("Other Skills", { _context })}</dt>
       <dd>
-        {#each skillsRequired as [skill, level], i}
-          <ItemLink type="skill" id={skill} showIcon={false} /> ({level}){#if i === skillsRequired.length - 2}{" and "}{:else if i !== skillsRequired.length - 1}{", "}{/if}
-        {:else}
-          {t("none")}
-        {/each}
+        <ul class="comma-separated and">
+          {#each skillsRequired as [skill, level]}
+            <li>
+              <ItemLink type="skill" id={skill} showIcon={false} /> ({level})
+            </li>
+          {/each}
+        </ul>
       </dd>
     {/if}
     <dt>{t("Time to Complete")}</dt>

--- a/src/types/VehiclePart.svelte
+++ b/src/types/VehiclePart.svelte
@@ -232,11 +232,17 @@ vehiclesContainingPart.sort((a, b) =>
     <dl>
       <dt>{t("Skills Required")}</dt>
       <dd>
-        {#each item.requirements?.install?.skills ?? [] as [skill, level], i}
-          <ItemLink type="skill" id={skill} showIcon={false} /> ({level}){#if i + 2 === item.requirements?.install?.skills?.length}{" and "}{:else if i + 1 !== item.requirements?.install?.skills?.length}{", "}{/if}
+        {#if item.requirements?.install?.skills?.length}
+          <ul class="comma-separated and">
+            {#each item.requirements?.install?.skills ?? [] as [skill, level]}
+              <li>
+                <ItemLink type="skill" id={skill} showIcon={false} /> ({level})
+              </li>
+            {/each}
+          </ul>
         {:else}
           {t("none")}
-        {/each}
+        {/if}
       </dd>
       <dt title="Time required goes down with better skills">
         {t("Time", { _context, _comment: "Time taken to perform the action" })}
@@ -257,11 +263,17 @@ vehiclesContainingPart.sort((a, b) =>
     <dl>
       <dt>{t("Skills Required")}</dt>
       <dd>
-        {#each item.requirements?.removal?.skills ?? [] as [skill, level], i}
-          <ItemLink type="skill" id={skill} showIcon={false} /> ({level}){#if i + 2 === item.requirements?.removal?.skills?.length}{" and "}{:else if i + 1 !== item.requirements?.removal?.skills?.length}{", "}{/if}
+        {#if item.requirements?.removal?.skills?.length}
+          <ul class="comma-separated and">
+            {#each item.requirements?.removal?.skills ?? [] as [skill, level]}
+              <li>
+                <ItemLink type="skill" id={skill} showIcon={false} /> ({level})
+              </li>
+            {/each}
+          </ul>
         {:else}
-          none
-        {/each}
+          {t("none")}
+        {/if}
       </dd>
       <dt title="Time required goes down with better skills">
         {t("Time", { _context, _comment: "Time taken to perform the action" })}
@@ -287,11 +299,17 @@ vehiclesContainingPart.sort((a, b) =>
     <dl>
       <dt>{t("Skills Required")}</dt>
       <dd>
-        {#each item.requirements.repair?.skills ?? [] as [skill, level], i}
-          <ItemLink type="skill" id={skill} showIcon={false} /> ({level}){#if i + 2 === item.requirements?.repair?.skills?.length}{" and "}{:else if i + 1 !== item.requirements?.repair?.skills?.length}{", "}{/if}
+        {#if item.requirements?.repair?.skills?.length}
+          <ul class="comma-separated and">
+            {#each item.requirements.repair?.skills ?? [] as [skill, level]}
+              <li>
+                <ItemLink type="skill" id={skill} showIcon={false} /> ({level})
+              </li>
+            {/each}
+          </ul>
         {:else}
           {t("none")}
-        {/each}
+        {/if}
       </dd>
       <dt title="Time required goes down with better skills">
         {t("Time", { _context, _comment: "Time taken to perform the action" })}

--- a/src/types/item/ArmorInfo.svelte
+++ b/src/types/item/ArmorInfo.svelte
@@ -239,7 +239,11 @@ function safeMaxEncumbrance(apd: ArmorPortionData | ArmorSlot): number | null {
         <dl>
           {#each armor as apd}
             <dt>
-              {#each coverageLabel(apd) as label, i}{#if i !== 0}{", "}{/if}{label}{/each}
+              <ul class="comma-separated">
+                {#each coverageLabel(apd) as label}
+                  <li>{label}</li>
+                {/each}
+              </ul>
             </dt>
             <dd>
               {apd.encumbrance ??
@@ -262,7 +266,11 @@ function safeMaxEncumbrance(apd: ArmorPortionData | ArmorSlot): number | null {
         <dl>
           {#each armor as apd}
             <dt>
-              {#each coverageLabel(apd) as label, i}{#if i !== 0}{", "}{/if}{label}{/each}
+              <ul class="comma-separated">
+                {#each coverageLabel(apd) as label}
+                  <li>{label}</li>
+                {/each}
+              </ul>
             </dt>
             <dd>{apd.coverage ?? 0}%</dd>
           {/each}


### PR DESCRIPTION
### Motivation
- Replace fragile manual separator injection (", ", `" and "`) used in `{#each}` loops with semantic list markup for consistency and maintainability.
- Use existing `ul.comma-separated` styling to preserve visual output while improving accessibility and HTML semantics.
- Keep translation and wording behavior (e.g. "and") identical by using the `.and` modifier class on lists where required.

### Description
- Replaced inline separator logic with semantic lists in the following views: `src/types/item/ArmorInfo.svelte` (coverage/encumbrance labels), `src/types/Construction.svelte`, `src/types/MartialArtRequirements.svelte`, `src/types/Fault.svelte`, `src/types/Recipe.svelte`, and `src/types/VehiclePart.svelte`.
- Skill/label sequences now render as `<ul class="comma-separated">` or `<ul class="comma-separated and">` with `<li>` children instead of manual `", "`/`" and "` string injections.
- Added conditional branches to render the existing empty-state text (e.g. `<em>{t("none")}</em>`) when no items are present to preserve original output.
- Ran code formatting to apply `prettier` style changes after the edits (`pnpm fix:format`).

### Testing
- Ran `pnpm fix:format` which completed successfully and formatted changed files.
- Ran `pnpm verify`, which executed `prettier -c`, `svelte-check`, and `tsc --noEmit`, and all checks passed. 
- Pre-commit lint-staged hooks ran during the commit and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698656976c208320887760fb68944391)