### PR TITLE
Fix byType duplication of canonical overrides

### DIFF
--- a/src/data.test.ts
+++ b/src/data.test.ts
@@ -8,7 +8,7 @@ import {
   singularName,
   omsName,
 } from "./data";
-import type { GunSlot, ItemBasicInfo, OvermapSpecial } from "./types";
+import type { OvermapSpecial } from "./types";
 
 test("flattened item group includes container item for distribution", () => {
   const data = new CBNData([
@@ -54,6 +54,29 @@ test("flattened item group includes container item for collection", () => {
     { id: "contained_thing", count: [1, 1], prob: "0.05", expected: 0.05 },
     { id: "other_thing", count: [1, 1], prob: "0.10", expected: 0.1 },
   ]);
+});
+
+test("byType returns canonical override entries without duplicate ids", () => {
+  const base = {
+    type: "GENERIC",
+    id: "test_item",
+    name: "Base item",
+    weight: "1 kg",
+  };
+  const modOverride = {
+    type: "GENERIC",
+    id: "test_item",
+    "copy-from": "test_item",
+    name: "Modded item",
+    relative: { weight: 100 },
+  };
+
+  const data = new CBNData([base, modOverride]);
+  const items = data.byType("item").filter((item) => item.id === "test_item");
+
+  expect(items).toHaveLength(1);
+  expect(items[0].weight).toBe(1100);
+  expect(singularName(items[0])).toBe("Modded item");
 });
 
 test("includes container item specified in item", () => {

--- a/src/data.ts
+++ b/src/data.ts
@@ -715,6 +715,8 @@ export class CBNData {
 
   /**
    * Retrieves all objects of a given type.
+   * For keyed object families, mod overrides are collapsed so each canonical key
+   * appears once (later entries win, stable order preserved).
    *
    * @param type The type of objects to retrieve.
    * @returns An array of flattened objects.
@@ -722,8 +724,30 @@ export class CBNData {
   byType<TypeName extends keyof SupportedTypesWithMapped>(
     type: TypeName,
   ): SupportedTypesWithMapped[TypeName][] {
-    const flattened =
-      this._byType.get(type)?.map((x) => this._flatten(x)) ?? [];
+    const raws = this._byType.get(type) ?? [];
+    const canonicalRaws: unknown[] = [];
+    const keyedIndex = new Map<string, number>();
+
+    for (const raw of raws) {
+      const key = this._provenanceKeyForObject(type, raw);
+      if (key == null) {
+        canonicalRaws.push(raw);
+        continue;
+      }
+
+      const existingIndex = keyedIndex.get(key);
+      if (existingIndex == null) {
+        keyedIndex.set(key, canonicalRaws.length);
+        canonicalRaws.push(raw);
+      } else {
+        // Keep stable order but replace earlier entry with later override.
+        canonicalRaws[existingIndex] = raw;
+      }
+    }
+
+    const flattened = canonicalRaws.map((x) =>
+      this._flatten(x),
+    ) as SupportedTypesWithMapped[TypeName][];
     if (type !== "monster") return flattened;
     return flattened.filter(
       (monster) =>


### PR DESCRIPTION
Summary:
- dedupe `byType` results by canonical keys so mod overrides replace base entries without duplicates
- add regression test that verifies `byType` only returns the override item and includes copied weight/name values

Testing:
- Not run (not requested)