### PR TITLE
fix: mitigate Safari freeze during prewarm

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -69,12 +69,14 @@ const INTRO_DASHBOARD_CONTEXT = "Intro dashboard";
 const LANGUAGE_SELECTOR_CONTEXT = "Language selector";
 const URL_MODS_CONTEXT = "URL mods";
 const PREWARM_IDLE_TIMEOUT_MS = 8000;
-const PREWARM_FALLBACK_DELAY_MS = 250;
 
 function schedulePrewarm(cbnData: CBNData): void {
   if (isTesting || typeof window === "undefined") return;
+  if (typeof window.requestIdleCallback !== "function") return;
+  if (document.visibilityState !== "visible") return;
 
   const runPrewarm = () => {
+    if (document.visibilityState !== "visible") return;
     const prewarmStart = nowTimeStamp();
     void prewarmDerivedCaches(cbnData)
       .then(() => {
@@ -89,13 +91,9 @@ function schedulePrewarm(cbnData: CBNData): void {
       });
   };
 
-  if ("requestIdleCallback" in window) {
-    window.requestIdleCallback(runPrewarm, {
-      timeout: PREWARM_IDLE_TIMEOUT_MS,
-    });
-  } else {
-    setTimeout(runPrewarm, PREWARM_FALLBACK_DELAY_MS);
-  }
+  window.requestIdleCallback(runPrewarm, {
+    timeout: PREWARM_IDLE_TIMEOUT_MS,
+  });
 }
 
 function arraysEqual(a: string[], b: string[]): boolean {

--- a/src/data.ts
+++ b/src/data.ts
@@ -43,6 +43,7 @@ import type { Loot } from "./types/item/spawnLocations";
 import { getDataJsonUrl } from "./constants";
 import { cleanText, formatKg, formatL, stripColorTags } from "./utils/format";
 import { HttpError, isNotFoundError } from "./utils/http-errors";
+import { yieldUntilIdle } from "./utils/idle";
 import { retry } from "./utils/retry";
 import { asArray } from "./utils/collections";
 
@@ -2733,11 +2734,11 @@ export async function prewarmDerivedCaches(targetData: CBNData): Promise<void> {
       terrainByOMSAppearance,
     } = await import("./types/item/spawnLocations");
 
-    await Promise.all([
-      lootByOMSAppearance(targetData),
-      furnitureByOMSAppearance(targetData),
-      terrainByOMSAppearance(targetData),
-    ]);
+    await lootByOMSAppearance(targetData);
+    await yieldUntilIdle();
+    await furnitureByOMSAppearance(targetData);
+    await yieldUntilIdle();
+    await terrainByOMSAppearance(targetData);
     prewarmedDerivedCaches.add(targetData);
   } catch (error) {
     // Keep prewarm best-effort: failures should not prevent future retries.

--- a/src/types/item/spawnLocations.ts
+++ b/src/types/item/spawnLocations.ts
@@ -1,16 +1,12 @@
 import type { CBNData } from "../../data";
 import type * as raw from "../../types";
 import { multimap, asArray } from "../../utils/collections";
-import { isTesting } from "../../utils/env";
+import { yieldUntilIdle } from "../../utils/idle";
 
 // Map generation constants
 const DEFAULT_CHANCE_PERCENTAGE = 100;
 const DEFAULT_MAPGEN_WEIGHT = 1000;
 const OMAP_TILE_SIZE = 24;
-
-// Performance/scheduling constants
-const IDLE_YIELD_TIMEOUT_MS = 1;
-const MIN_TIME_REMAINING_MS = 0;
 
 /** 0.0 <= chance <= 1.0 */
 type chance = number;
@@ -322,32 +318,6 @@ function offsetMapgen(
         min(p.y) < my + OMAP_TILE_SIZE,
     );
   return { ...mapgen, object };
-}
-
-const requestIdleCallback: typeof window.requestIdleCallback =
-  typeof window !== "undefined" && "requestIdleCallback" in window
-    ? window.requestIdleCallback
-    : function (cb: (deadline: IdleDeadline) => void): number {
-        const start = Date.now();
-        return setTimeout(function () {
-          cb({
-            didTimeout: false,
-            timeRemaining: function () {
-              return Math.max(0, 50 - (Date.now() - start));
-            },
-          });
-        }, 0) as unknown as number;
-      };
-
-function yieldUntilIdle(): Promise<IdleDeadline> {
-  if (isTesting)
-    return Promise.resolve({
-      didTimeout: false,
-      timeRemaining: () => 100,
-    });
-  return new Promise<IdleDeadline>((resolve) => {
-    requestIdleCallback(resolve, { timeout: IDLE_YIELD_TIMEOUT_MS });
-  });
 }
 
 const canInputPending =

--- a/src/utils/idle.ts
+++ b/src/utils/idle.ts
@@ -1,0 +1,37 @@
+import { isTesting } from "./env";
+
+const DEFAULT_IDLE_YIELD_TIMEOUT_MS = 1;
+
+const requestIdleCallbackCompat: typeof window.requestIdleCallback =
+  typeof window !== "undefined" &&
+  typeof window.requestIdleCallback === "function"
+    ? window.requestIdleCallback.bind(window)
+    : function (cb: (deadline: IdleDeadline) => void): number {
+        const start = Date.now();
+        return setTimeout(function () {
+          cb({
+            didTimeout: false,
+            timeRemaining: function () {
+              return Math.max(0, 50 - (Date.now() - start));
+            },
+          });
+        }, 0) as unknown as number;
+      };
+
+/**
+ * Yield execution until the browser has idle time available.
+ * Falls back to a setTimeout-based shim when requestIdleCallback is unavailable.
+ */
+export function yieldUntilIdle(
+  timeoutMs: number = DEFAULT_IDLE_YIELD_TIMEOUT_MS,
+): Promise<IdleDeadline> {
+  if (isTesting)
+    return Promise.resolve({
+      didTimeout: false,
+      timeRemaining: () => 100,
+    });
+
+  return new Promise<IdleDeadline>((resolve) => {
+    requestIdleCallbackCompat(resolve, { timeout: timeoutMs });
+  });
+}


### PR DESCRIPTION
## Summary
- run prewarm only when `requestIdleCallback` is available and the page is visible
- split prewarm cache warming into sequential stages instead of running all heavy computations in parallel
- extract robust idle yielding into `src/utils/idle.ts` and reuse it from both prewarm orchestration and spawn location processing

## Why
This reduces CPU/memory spikes that could freeze or reload iPad Safari tabs after release while keeping prewarm best-effort.

## Validation
- `pnpm verify:types`
- `pnpm vitest run src/types/item/spawnLocations.test.ts src/data.test.ts`