### PR TITLE
Fix mixed blueprint and parts vehicle normalization

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -2442,26 +2442,29 @@ export type NormalizedVehicleMountedPart = {
 export const normalizeVehicleMountedParts = (
   vehicle: Vehicle,
 ): NormalizedVehicleMountedPart[] => {
+  const ret: NormalizedVehicleMountedPart[] = [];
+
   if (vehicle.parts) {
-    return vehicle.parts.map((part) => ({
-      x: part.x,
-      y: part.y,
-      parts:
-        (part.part
-          ? [{ part: part.part, fuel: part.fuel }]
-          : part.parts?.map((p) =>
-              typeof p === "string" ? { part: p } : p,
-            )) ?? [],
-    }));
+    ret.push(
+      ...vehicle.parts.map((part) => ({
+        x: part.x,
+        y: part.y,
+        parts:
+          (part.part
+            ? [{ part: part.part, fuel: part.fuel }]
+            : part.parts?.map((p) =>
+                typeof p === "string" ? { part: p } : p,
+              )) ?? [],
+      })),
+    );
   }
 
-  if (!vehicle.blueprint || !vehicle.palette) return [];
+  if (!vehicle.blueprint || !vehicle.palette) return ret;
 
   const origin = vehicle.blueprint_origin ?? { x: 0, y: 0 };
   const rows = vehicle.blueprint.map((row) =>
     Array.isArray(row) ? row.join("") : row,
   );
-  const ret: NormalizedVehicleMountedPart[] = [];
 
   for (const [rowIndex, row] of rows.entries()) {
     for (const [colIndex, symbol] of [...row].entries()) {
@@ -2476,8 +2479,10 @@ export const normalizeVehicleMountedParts = (
       if (!parts.length) continue;
 
       ret.push({
-        x: rowIndex - origin.y,
-        y: colIndex - origin.x,
+        // Match Cataclysm-BN's vehicle blueprint loader in `veh_type.cpp`,
+        // which uses column -> x and row -> y after subtracting the origin.
+        x: colIndex - origin.x,
+        y: rowIndex - origin.y,
         parts,
       });
     }

--- a/src/vehicleParts.test.ts
+++ b/src/vehicleParts.test.ts
@@ -45,8 +45,8 @@ describe("normalizeVehicleMountedParts", () => {
 
     expect(normalizeVehicleMountedParts(vehicle)).toEqual([
       {
-        x: 0,
-        y: -1,
+        x: -1,
+        y: 0,
         parts: [{ part: "frame" }],
       },
       {
@@ -55,9 +55,41 @@ describe("normalizeVehicleMountedParts", () => {
         parts: [{ part: "seat" }, { part: "roof" }],
       },
       {
+        x: 0,
+        y: 1,
+        parts: [{ part: "wheel" }],
+      },
+    ]);
+  });
+
+  test("combines legacy parts with blueprint + palette format", () => {
+    const vehicle: Vehicle = {
+      id: "mixed_vehicle",
+      type: "vehicle",
+      name: "Mixed vehicle",
+      parts: [{ x: 0, y: 0, part: "tank", fuel: "gasoline" }],
+      blueprint: ["AB"],
+      palette: {
+        A: ["frame"],
+        B: ["seat"],
+      },
+    };
+
+    expect(normalizeVehicleMountedParts(vehicle)).toEqual([
+      {
+        x: 0,
+        y: 0,
+        parts: [{ part: "tank", fuel: "gasoline" }],
+      },
+      {
+        x: 0,
+        y: 0,
+        parts: [{ part: "frame" }],
+      },
+      {
         x: 1,
         y: 0,
-        parts: [{ part: "wheel" }],
+        parts: [{ part: "seat" }],
       },
     ]);
   });


### PR DESCRIPTION
## Summary
- ensure legacy `parts` definitions are preserved when a vehicle also defines a blueprint/palette
- align blueprint coordinate normalization with Cataclysm-BN’s row/column mapping
- expand tests to cover combined legacy and blueprint loading

| [Blimp](https://fd7ca92b.cbn-guide.pages.dev/stable/vehicle/blimp) |  [Airship](https://fd7ca92b.cbn-guide.pages.dev/stable/vehicle/airship) |
|--------|--------|
| <img width="400" src="https://github.com/user-attachments/assets/1bc5d71e-991b-4bfb-85a6-2f3d4fbd6c1a" /> | <img width="400" src="https://github.com/user-attachments/assets/67a783e9-2627-47ba-b60b-a44d7c670826" /> | 


