### PR TITLE
Normalize vehicle palette object entries

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -39,6 +39,7 @@ import type {
   Translation,
   UseFunction,
   Vehicle,
+  VehicleMountedPartDefinition,
 } from "./types";
 import type { Loot } from "./types/item/spawnLocations";
 import {
@@ -2357,7 +2358,7 @@ export const getVehiclePartIdAndVariant = (
 export type NormalizedVehicleMountedPart = {
   x: number;
   y: number;
-  parts: { part: string; fuel?: string }[];
+  parts: VehicleMountedPartDefinition[];
 };
 
 export const normalizeVehicleMountedParts = (
@@ -2394,6 +2395,10 @@ export const normalizeVehicleMountedParts = (
 
       const parts = paletteEntries.flatMap((entry) => {
         if (typeof entry === "string") return [{ part: entry }];
+        if (!Array.isArray(entry)) return [entry];
+
+        // Cataclysm-BN's blueprint palette loader uses only the first element as
+        // the vehicle part id and ignores any extra legacy metadata in the array.
         const [part] = entry;
         return typeof part === "string" ? [{ part }] : [];
       });

--- a/src/types.ts
+++ b/src/types.ts
@@ -2014,11 +2014,14 @@ export type Vehicle = {
   name: Translation;
   blueprint?: string[][] | string[];
   blueprint_origin?: { x: integer; y: integer };
-  palette?: Record<string, (string | string[])[]>;
+  palette?: Record<
+    string,
+    (string | string[] | VehicleMountedPartDefinition)[]
+  >;
   parts?: {
     x: integer;
     y: integer;
-    parts?: (string | { part: string; fuel?: string })[];
+    parts?: (string | VehicleMountedPartDefinition)[];
     part?: string;
     fuel?: string;
   }[];
@@ -2029,6 +2032,14 @@ export type Vehicle = {
     items?: string | string[];
     item_groups?: string | string[];
   }[];
+};
+
+export type VehicleMountedPartDefinition = {
+  part: string;
+  fuel?: string;
+  ammo?: integer;
+  ammo_types?: string[];
+  ammo_qty?: [integer, integer];
 };
 
 export type WeaponCategory = {

--- a/src/vehicleParts.test.ts
+++ b/src/vehicleParts.test.ts
@@ -93,4 +93,62 @@ describe("normalizeVehicleMountedParts", () => {
       },
     ]);
   });
+
+  test("normalizes object palette entries with fuel and ammo metadata", () => {
+    const vehicle: Vehicle = {
+      id: "object_palette_vehicle",
+      type: "vehicle",
+      name: "Object palette vehicle",
+      blueprint: ["AB"],
+      palette: {
+        A: [
+          "frame",
+          {
+            part: "fuel_bunker",
+            fuel: "coal_lump",
+          },
+        ],
+        B: [
+          "turret_mount_manual_wood",
+          {
+            part: "mounted_launcher_ballista",
+            ammo: 75,
+            ammo_types: [
+              "rock",
+              "sling_bullet",
+              "ammo_ballista_wood",
+              "ammo_ballista_iron",
+            ],
+            ammo_qty: [1, 10],
+          },
+        ],
+      },
+    };
+
+    expect(normalizeVehicleMountedParts(vehicle)).toEqual([
+      {
+        x: 0,
+        y: 0,
+        parts: [{ part: "frame" }, { part: "fuel_bunker", fuel: "coal_lump" }],
+      },
+      {
+        x: 1,
+        y: 0,
+        parts: [
+          { part: "turret_mount_manual_wood" },
+          {
+            part: "mounted_launcher_ballista",
+            ammo: 75,
+            ammo_types: [
+              "rock",
+              "sling_bullet",
+              "ammo_ballista_wood",
+              "ammo_ballista_iron",
+            ],
+            ammo_qty: [1, 10],
+          },
+        ],
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
Summary
- Normalize vehicle mounted entries so object palette entries with fuel/ammo metadata survive the schema round trip, keeping the mirror faithful to BN source
- Relax Vehicle/parts typings and list helpers so palettes can expose richer metadata without forcing bindings to drop context

<img width="686" height="1120" alt="CleanShot 2026-03-12 at 19 19 04" src="https://github.com/user-attachments/assets/e6a55c57-b350-415f-9881-02e78e8a6e78" />
