### PR TITLE
fix: align furniture construction rendering with BN data

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -97,8 +97,10 @@ export type Construction = {
       )[];
   pre_note?: string;
 
-  pre_terrain?: string; // if starts with f_, then furniture_id, else terrain_id
-  post_terrain?: string; // as above
+  pre_terrain?: string;
+  pre_furniture?: string;
+  post_terrain?: string;
+  post_furniture?: string;
 
   pre_flags?: string | string[];
   post_flags?: string[];

--- a/src/types/Construction.svelte
+++ b/src/types/Construction.svelte
@@ -5,6 +5,11 @@ import JsonView from "../JsonView.svelte";
 import { getContext, untrack } from "svelte";
 import { CBNData } from "../data";
 import type { Construction, RequirementData } from "../types";
+import {
+  getConstructionPrerequisites,
+  getConstructionResults,
+  isNullConstructionResult,
+} from "./construction";
 import ItemLink from "./ItemLink.svelte";
 import RequirementDataTools from "./item/RequirementDataTools.svelte";
 import { i18n, gameSingular, gameSingularName } from "../utils/i18n";
@@ -42,6 +47,8 @@ const components = requirements.flatMap(([req, count]) => {
 const byproducts = data.flattenItemGroup(
   data.normalizeItemGroup(construction.byproducts, "collection"),
 );
+const prerequisites = getConstructionPrerequisites(construction);
+const results = getConstructionResults(construction);
 
 const preFlags: { flag: string; force_terrain?: boolean }[] = [];
 if (construction.pre_flags)
@@ -71,14 +78,16 @@ if (construction.pre_flags)
         ? `${construction.time} m`
         : (construction.time ?? "0 m")}
     </dd>
-    {#if construction.pre_terrain}
+    {#if prerequisites.length}
       <dt>{t("Requires", { _context })}</dt>
       <dd>
-        <ItemLink
-          type={construction.pre_terrain.startsWith("f_")
-            ? "furniture"
-            : "terrain"}
-          id={construction.pre_terrain} />
+        <ul class="comma-separated">
+          {#each prerequisites as prerequisite}
+            <li>
+              <ItemLink type={prerequisite.type} id={prerequisite.id} />
+            </li>
+          {/each}
+        </ul>
       </dd>
     {/if}
     {#if preFlags.length}
@@ -118,23 +127,25 @@ if (construction.pre_flags)
         </ul>
       </dd>
     {/if}
-    {#if !includeTitle && construction.post_terrain}
+    {#if !includeTitle && results.length}
       <dt>{t("Creates", { _context })}</dt>
       <dd>
-        {#if construction.post_terrain === "f_null"}
-          <em
-            >{t("nothing", {
-              _context,
-              _comment:
-                'The furniture/terrain "created" by a deconstruction is...',
-            })}</em>
-        {:else}
-          <ItemLink
-            type={construction.post_terrain.startsWith("f_")
-              ? "furniture"
-              : "terrain"}
-            id={construction.post_terrain} />
-        {/if}
+        <ul class="comma-separated">
+          {#each results as result}
+            <li>
+              {#if isNullConstructionResult(result)}
+                <em
+                  >{t("nothing", {
+                    _context,
+                    _comment:
+                      'The furniture/terrain "created" by a deconstruction is...',
+                  })}</em>
+              {:else}
+                <ItemLink type={result.type} id={result.id} />
+              {/if}
+            </li>
+          {/each}
+        </ul>
       </dd>
     {/if}
   </dl>

--- a/src/types/Construction.test.ts
+++ b/src/types/Construction.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { render } from "@testing-library/svelte";
+import { describe, expect, it } from "vitest";
+import WithData from "../WithData.svelte";
+import { CBNData } from "../data";
+import Construction from "./Construction.svelte";
+
+describe("Construction", () => {
+  it("renders furniture prerequisites and null furniture results", () => {
+    const data = new CBNData([
+      {
+        type: "construction_group",
+        id: "advanced_object_deconstruction",
+        name: "Advanced Object Deconstruction",
+      },
+      {
+        type: "construction",
+        id: "constr_remove_object_fireplace",
+        group: "advanced_object_deconstruction",
+        category: "OTHER",
+        time: "90 m",
+        required_skills: [["fabrication", 2]],
+        pre_furniture: "f_fireplace",
+        post_furniture: "f_null",
+      },
+      {
+        type: "furniture",
+        id: "f_fireplace",
+        name: "fireplace",
+        description: "A warm test fixture.",
+        move_cost_mod: 0,
+        required_str: 0,
+      },
+    ]);
+
+    const { getByText } = render(WithData, {
+      Component: Construction,
+      data,
+      construction: data.byId("construction", "constr_remove_object_fireplace"),
+    });
+
+    expect(getByText("Requires")).toBeTruthy();
+    expect(getByText("fireplace")).toBeTruthy();
+    expect(getByText("Creates")).toBeTruthy();
+    expect(getByText("nothing")).toBeTruthy();
+  });
+
+  it("renders terrain prerequisites and furniture results without prefix inference", () => {
+    const data = new CBNData([
+      {
+        type: "construction_group",
+        id: "build_beaded_door",
+        name: "Build Beaded Door",
+      },
+      {
+        type: "construction",
+        id: "constr_beaded_door",
+        group: "build_beaded_door",
+        category: "OTHER",
+        time: "30 m",
+        required_skills: [["fabrication", 1]],
+        pre_terrain: "t_door_frame",
+        post_furniture: "f_beaded_door",
+      },
+      {
+        type: "terrain",
+        id: "t_door_frame",
+        name: "door frame",
+        description: "A test door frame.",
+      },
+      {
+        type: "furniture",
+        id: "f_beaded_door",
+        name: "beaded door",
+        description: "A test beaded door.",
+        move_cost_mod: 0,
+        required_str: 0,
+      },
+    ]);
+
+    const { getByText } = render(WithData, {
+      Component: Construction,
+      data,
+      construction: data.byId("construction", "constr_beaded_door"),
+    });
+
+    expect(getByText("door frame")).toBeTruthy();
+    expect(getByText("beaded door")).toBeTruthy();
+  });
+});

--- a/src/types/Furniture.svelte
+++ b/src/types/Furniture.svelte
@@ -44,7 +44,7 @@ const bash = item.bash?.items
 
 const constructions = data
   .byType("construction")
-  .filter((c) => c.post_terrain === item.id);
+  .filter((c) => c.post_furniture === item.id);
 
 const bashedFrom = data
   .byType("furniture")

--- a/src/types/Furniture.test.ts
+++ b/src/types/Furniture.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { render } from "@testing-library/svelte";
+import { describe, expect, it } from "vitest";
+import WithData from "../WithData.svelte";
+import { CBNData } from "../data";
+import Furniture from "./Furniture.svelte";
+
+describe("Furniture", () => {
+  it("shows furniture constructions from post_furniture", () => {
+    const data = new CBNData([
+      {
+        type: "construction_group",
+        id: "build_sign",
+        name: "Build Sign",
+      },
+      {
+        type: "construction_group",
+        id: "dig_pit",
+        name: "Dig Pit",
+      },
+      {
+        type: "construction",
+        id: "constr_sign",
+        group: "build_sign",
+        category: "OTHER",
+        time: "20 m",
+        required_skills: [["fabrication", 0]],
+        post_furniture: "f_sign",
+      },
+      {
+        type: "construction",
+        id: "constr_pit",
+        group: "dig_pit",
+        category: "OTHER",
+        time: "30 m",
+        required_skills: [["fabrication", 0]],
+        post_terrain: "t_pit",
+      },
+      {
+        type: "furniture",
+        id: "f_sign",
+        name: "sign",
+        description: "Read it. Warnings ahead.",
+        move_cost_mod: 0,
+        required_str: 0,
+      },
+      {
+        type: "terrain",
+        id: "t_pit",
+        name: "pit",
+        description: "A test pit.",
+      },
+    ]);
+
+    const { getByText, queryByText } = render(WithData, {
+      Component: Furniture,
+      data,
+      item: data.byId("furniture", "f_sign"),
+    });
+
+    expect(getByText("Construction")).toBeTruthy();
+    expect(getByText("Build Sign")).toBeTruthy();
+    expect(queryByText("Dig Pit")).toBeNull();
+  });
+});

--- a/src/types/ToolQuality.svelte
+++ b/src/types/ToolQuality.svelte
@@ -5,8 +5,9 @@ import { getContext, untrack } from "svelte";
 import { CBNData } from "../data";
 import LimitedList from "../LimitedList.svelte";
 import type { Construction, Item, ToolQuality, VehiclePart } from "../types";
+import { getConstructionPrerequisites } from "./construction";
 import ItemLink from "./ItemLink.svelte";
-import { byName, i18n, gameSingularName } from "../utils/i18n";
+import { byName, gameSingularName } from "../utils/i18n";
 
 interface Props {
   item: ToolQuality;
@@ -206,13 +207,13 @@ constructionsUsingQualityByLevelList.forEach(([, constructions]) => {
                 id={f.group}
                 type="construction_group"
                 showIcon={false} />
-              {#if f.pre_terrain}
-                on {#each [f.pre_terrain].flat() as preTerrain, i}
-                  {@const itemType = preTerrain.startsWith("f_")
-                    ? "furniture"
-                    : "terrain"}
-                  {#if i !== 0}{i18n.__(" OR ")}{/if}
-                  <ItemLink type={itemType} id={preTerrain} />
+              {@const prerequisites = getConstructionPrerequisites(f)}
+              {#if prerequisites.length}
+                {t("on")}
+                {#each prerequisites as prerequisite, i}
+                  {#if i !== 0},
+                  {/if}
+                  <ItemLink type={prerequisite.type} id={prerequisite.id} />
                 {/each}
               {/if}
             {/snippet}

--- a/src/types/construction.ts
+++ b/src/types/construction.ts
@@ -1,0 +1,53 @@
+import type { Construction } from "../types";
+
+export type ConstructionSurfaceTarget = {
+  id: string;
+  type: "terrain" | "furniture";
+};
+
+/**
+ * Collect prerequisite terrain/furniture targets using explicit fields.
+ */
+export function getConstructionPrerequisites(
+  construction: Pick<Construction, "pre_terrain" | "pre_furniture">,
+): ConstructionSurfaceTarget[] {
+  const prerequisites: ConstructionSurfaceTarget[] = [];
+
+  if (construction.pre_terrain) {
+    prerequisites.push({ id: construction.pre_terrain, type: "terrain" });
+  }
+
+  if (construction.pre_furniture) {
+    prerequisites.push({ id: construction.pre_furniture, type: "furniture" });
+  }
+
+  return prerequisites;
+}
+
+/**
+ * Collect output terrain/furniture targets using explicit fields.
+ */
+export function getConstructionResults(
+  construction: Pick<Construction, "post_terrain" | "post_furniture">,
+): ConstructionSurfaceTarget[] {
+  const results: ConstructionSurfaceTarget[] = [];
+
+  if (construction.post_terrain) {
+    results.push({ id: construction.post_terrain, type: "terrain" });
+  }
+
+  if (construction.post_furniture) {
+    results.push({ id: construction.post_furniture, type: "furniture" });
+  }
+
+  return results;
+}
+
+export function isNullConstructionResult(
+  result: ConstructionSurfaceTarget,
+): boolean {
+  return (
+    (result.type === "terrain" && result.id === "t_null") ||
+    (result.type === "furniture" && result.id === "f_null")
+  );
+}

--- a/src/types/item/ComponentOf.svelte
+++ b/src/types/item/ComponentOf.svelte
@@ -4,7 +4,8 @@ import { getContext, untrack } from "svelte";
 import { CBNData } from "../../data";
 import LimitedList from "../../LimitedList.svelte";
 import ItemLink from "../ItemLink.svelte";
-import { i18n, gameSingularName } from "../../utils/i18n";
+import { getConstructionPrerequisites } from "../construction";
+import { gameSingularName } from "../../utils/i18n";
 
 interface Props {
   item_id: string;
@@ -128,13 +129,13 @@ const toolResults = [...toolRecipes].sort((a, b) =>
         <LimitedList items={constructions}>
           {#snippet children({ item: f })}
             <ItemLink id={f.group} type="construction_group" showIcon={false} />
-            {#if f.pre_terrain}
-              on {#each [f.pre_terrain].flat() as preTerrain, i}
-                {@const itemType = preTerrain.startsWith("f_")
-                  ? "furniture"
-                  : "terrain"}
-                {#if i !== 0}{i18n.__(" OR ")}{/if}
-                <ItemLink type={itemType} id={preTerrain} />
+            {@const prerequisites = getConstructionPrerequisites(f)}
+            {#if prerequisites.length}
+              {t("on")}
+              {#each prerequisites as prerequisite, i}
+                {#if i !== 0},
+                {/if}
+                <ItemLink type={prerequisite.type} id={prerequisite.id} />
               {/each}
             {/if}
           {/snippet}
@@ -152,13 +153,13 @@ const toolResults = [...toolRecipes].sort((a, b) =>
         <LimitedList items={toolConstructions}>
           {#snippet children({ item: f })}
             <ItemLink id={f.group} type="construction_group" showIcon={false} />
-            {#if f.pre_terrain}
-              on {#each [f.pre_terrain].flat() as preTerrain, i}
-                {@const itemType = preTerrain.startsWith("f_")
-                  ? "furniture"
-                  : "terrain"}
-                {#if i !== 0}{i18n.__(" OR ")}{/if}
-                <ItemLink type={itemType} id={preTerrain} />
+            {@const prerequisites = getConstructionPrerequisites(f)}
+            {#if prerequisites.length}
+              {t("on")}
+              {#each prerequisites as prerequisite, i}
+                {#if i !== 0},
+                {/if}
+                <ItemLink type={prerequisite.type} id={prerequisite.id} />
               {/each}
             {/if}
           {/snippet}

--- a/src/types/item/ConstructionByproduct.svelte
+++ b/src/types/item/ConstructionByproduct.svelte
@@ -5,7 +5,8 @@ import { getContext } from "svelte";
 import { CBNData } from "../../data";
 import LimitedList from "../../LimitedList.svelte";
 import ItemLink from "../ItemLink.svelte";
-import { byName, i18n } from "../../utils/i18n";
+import { getConstructionPrerequisites } from "../construction";
+import { byName } from "../../utils/i18n";
 
 interface Props {
   item_id: string;
@@ -32,13 +33,13 @@ const constructions = data
     <LimitedList items={constructions}>
       {#snippet children({ item: f })}
         <ItemLink id={f.group} type="construction_group" showIcon={false} />
-        {#if f.pre_terrain}
-          on {#each [f.pre_terrain].flat() as preTerrain, i}
-            {@const itemType = preTerrain.startsWith("f_")
-              ? "furniture"
-              : "terrain"}
-            {#if i !== 0}{i18n.__(" OR ")}{/if}
-            <ItemLink type={itemType} id={preTerrain} />
+        {@const prerequisites = getConstructionPrerequisites(f)}
+        {#if prerequisites.length}
+          {t("on")}
+          {#each prerequisites as prerequisite, i}
+            {#if i !== 0},
+            {/if}
+            <ItemLink type={prerequisite.type} id={prerequisite.id} />
           {/each}
         {/if}
       {/snippet}


### PR DESCRIPTION
## Summary
- add explicit BN furniture construction fields and central helpers for terrain/furniture construction links
- show furniture page construction sections from `post_furniture` instead of terrain-only lookups
- remove legacy `f_` prefix inference from construction views and add focused regression tests

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm vitest run src --exclude "src/all.*.test.ts" --exclude "src/__mod_tests__/**" --no-color`
- browser check against `http://127.0.0.1:3000/stable/furniture/f_sign`

Closes #135