### PR TITLE
Traps support

### DIFF
--- a/scripts/gen-sitemap.ts
+++ b/scripts/gen-sitemap.ts
@@ -44,6 +44,7 @@ const ENTITY_TYPES = [
   "monster",
   "terrain",
   "furniture",
+  "trap",
   "vehicle_part",
   "mutation",
   "martial_art",

--- a/src/Thing.svelte
+++ b/src/Thing.svelte
@@ -21,6 +21,7 @@ import MutationCategory from "./types/MutationCategory.svelte";
 import MutationType from "./types/MutationType.svelte";
 import Vehicle from "./types/Vehicle.svelte";
 import Terrain from "./types/Terrain.svelte";
+import Trap from "./types/Trap.svelte";
 import WeaponCategory from "./types/WeaponCategory.svelte";
 import ConstructionGroup from "./types/ConstructionGroup.svelte";
 import Achievement from "./types/Achievement.svelte";
@@ -103,6 +104,7 @@ const displays: Record<string, Component<any>> = {
   mutation_type: MutationType,
   vehicle: Vehicle,
   terrain: Terrain,
+  trap: Trap,
   weapon_category: WeaponCategory,
   construction_group: ConstructionGroup,
   achievement: Achievement,

--- a/src/data.ts
+++ b/src/data.ts
@@ -36,6 +36,7 @@ import type {
   RequirementData,
   SupportedTypeMapped,
   SupportedTypesWithMapped,
+  Trap,
   Translation,
   UseFunction,
   Vehicle,
@@ -2035,6 +2036,23 @@ export class CBNData {
     ];
   }
 
+  #disarmTrapIndex = new ReverseIndex(this, "trap", (trap) => {
+    const droppedItems = trap.drops
+      ?.map((drop) => (typeof drop === "string" ? drop : drop.item))
+      .filter((drop): drop is string => typeof drop === "string");
+    return [...new Set(droppedItems ?? [])];
+  });
+  disarmTrap(item_id: string): Trap[] {
+    return this.#disarmTrapIndex.lookup(item_id).sort(byName);
+  }
+
+  #constructTrapIndex = new ReverseIndex(this, "item", (item) =>
+    trapIdsFromUseAction(item.use_action),
+  );
+  constructsTrap(trap_id: string): Item[] {
+    return this.#constructTrapIndex.lookup(trap_id).sort(byName);
+  }
+
   setLocale(localeJson: any, pinyinNameJson: any) {
     if (pinyinNameJson) pinyinNameJson[""] = localeJson[""];
     i18n.loadJSON(localeJson);
@@ -2465,6 +2483,17 @@ export function normalizeUseAction(action: Item["use_action"]): UseFunction[] {
   } else {
     return action ? [action] : [];
   }
+}
+
+function trapIdsFromUseAction(action: Item["use_action"]): string[] {
+  const trapIds = new Set<string>();
+  for (const useAction of normalizeUseAction(action)) {
+    if (useAction.type !== "place_trap") continue;
+    trapIds.add(useAction.trap);
+    if (useAction.outer_layer_trap) trapIds.add(useAction.outer_layer_trap);
+    if (useAction.bury?.trap) trapIds.add(useAction.bury.trap);
+  }
+  return [...trapIds];
 }
 
 const fetchJsonWithProgress = (

--- a/src/i18n/transifex-static.ts
+++ b/src/i18n/transifex-static.ts
@@ -133,6 +133,8 @@ export function translateType(type: keyof SupportedTypesWithMapped): string {
       return t("Techniques");
     case "terrain":
       return t("Terrain");
+    case "trap":
+      return t("Traps");
     case "tool_quality":
       return t("Qualities");
     case "uncraft":

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -447,6 +447,7 @@ export function isSupportedType(
     "uncraft",
     "vehicle",
     "vehicle_part",
+    "trap",
   ]);
   return supportedTypes.has(type);
 }

--- a/src/search-engine.ts
+++ b/src/search-engine.ts
@@ -18,6 +18,7 @@ export const SEARCHABLE_TYPES = new Set<keyof SupportedTypesWithMapped>([
   "terrain",
   "skill",
   "overmap_special",
+  "trap",
 ]);
 
 export type SearchTarget = {

--- a/src/seo.ts
+++ b/src/seo.ts
@@ -7,6 +7,7 @@ import type {
   ItemBasicInfo,
   SupportedTypeMapped,
   SupportedTypes,
+  Trap,
   VehiclePart,
 } from "./types";
 import { get } from "svelte/store";
@@ -204,6 +205,14 @@ const descriptionForItem = (item: SupportedTypeMapped): string => {
   return cleanText(desc);
 };
 
+const statsForTrap = (item: Trap): string[] => {
+  const stats: string[] = [];
+  if (item.visibility != null) stats.push(formatStat("vis", item.visibility));
+  if (item.avoidance != null) stats.push(formatStat("avoid", item.avoidance));
+  if (item.difficulty != null) stats.push(formatStat("diff", item.difficulty));
+  return stats;
+};
+
 const statsRenderers: Partial<{
   [K in keyof SupportedTypes]: (item: SupportedTypes[K]) => string[];
 }> = {
@@ -225,6 +234,7 @@ const statsRenderers: Partial<{
   TOOL_ARMOR: statsForArmor,
   WHEEL: statsForGeneric,
   furniture: statsForFurniture,
+  trap: statsForTrap,
   vehicle_part: statsForVehiclePart,
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -475,6 +475,7 @@ export type UseFunction =
   | MessageUseFunction
   | MulticookerUseFunction
   | MusicPlayerUseFunction
+  | PlaceTrapUseFunction
   | PocketDimensionUseFunction
   | ProspectPickUseFunction
   | RepairItemUseFunction
@@ -505,7 +506,6 @@ export type UseFunction =
         | "mutagen_iv"
         | "place_monster"
         | "place_npc"
-        | "place_trap"
         | "reveal_map"
         | "salvage"
         | "set_transform"
@@ -595,6 +595,15 @@ export type DimensionTravelUseFunction = {
 type ItemActionUseFunction = {
   type: "__item_action__";
   id: string;
+};
+
+export type PlaceTrapUseFunction = {
+  type: "place_trap";
+  trap: string;
+  outer_layer_trap?: string;
+  bury?: {
+    trap?: string;
+  };
 };
 
 export type TransformUseFunction = {
@@ -1021,6 +1030,37 @@ export type Technique = {
   flags?: string[];
 } & MartialArtRequirements &
   BonusContainer;
+
+export type TrapDrop =
+  | string
+  | {
+      item?: string; // item_id
+      quantity?: number;
+      charges?: number;
+    };
+
+export type Trap = {
+  id: string;
+  type: "trap";
+  name: Translation | string;
+  color?: string;
+  symbol?: string;
+  looks_like?: string;
+  visibility: number;
+  avoidance: number;
+  difficulty: number;
+  action: string;
+  benign?: boolean;
+  remove_on_trigger?: boolean;
+  always_invisible?: boolean;
+  funnel_radius?: number;
+  comfort?: number;
+  floor_bedding_warmth?: number;
+  trigger_weight?: string;
+  trap_radius?: number;
+  drops?: TrapDrop[];
+  trigger_items?: TrapDrop[];
+};
 
 export type Vitamin = {
   id: string;
@@ -2299,6 +2339,7 @@ export type SupportedTypes = {
   sub_body_part: SubBodyPart;
   technique: Technique;
   terrain: Terrain;
+  trap: Trap;
   tool_quality: ToolQuality;
   uncraft: { type: "uncraft" } & Recipe;
   vehicle: Vehicle;

--- a/src/types/Item.svelte
+++ b/src/types/Item.svelte
@@ -30,6 +30,7 @@ import ContainerInfo from "./item/Container.svelte";
 import ConstructionByproduct from "./item/ConstructionByproduct.svelte";
 import Deconstruct from "./item/Deconstruct.svelte";
 import Disassembly from "./item/Disassembly.svelte";
+import DisarmTrap from "./item/DisarmTrap.svelte";
 import DissectedFrom from "./item/DissectedFrom.svelte";
 import DroppedBy from "./item/DroppedBy.svelte";
 import Foraged from "./item/Foraged.svelte";
@@ -487,6 +488,7 @@ function normalizeStackVolume(item: Item): (string | number) | undefined {
   <ConstructionByproduct item_id={item.id} />
   <Deconstruct item_id={item.id} />
   <Bash item_id={item.id} />
+  <DisarmTrap item_id={item.id} />
   <DroppedBy item_id={item.id} />
   <SpawnedIn item_id={item.id} />
   <SpawnedInVehicle item_id={item.id} />

--- a/src/types/Trap.svelte
+++ b/src/types/Trap.svelte
@@ -1,0 +1,159 @@
+<script lang="ts">
+import { t } from "@transifex/native";
+import { getContext, untrack } from "svelte";
+import { countsByCharges, type CBNData } from "../data";
+import type { Trap, TrapDrop } from "../types";
+import LimitedList from "../LimitedList.svelte";
+import ItemLink from "./ItemLink.svelte";
+
+const data = getContext<CBNData>("data");
+const _context = "Trap";
+
+interface Props {
+  item: Trap;
+}
+
+let { item: sourceItem }: Props = $props();
+const item = untrack(() => sourceItem);
+
+const actionNames: Record<string, string> = {
+  none: t("None", { _context: "Trap action" }),
+  crossbow: t("Crossbow Shot", { _context: "Trap action" }),
+  board: t("Spiked Board", { _context: "Trap action" }),
+  beartrap: t("Bear Trap", { _context: "Trap action" }),
+  landmine: t("Landmine Explosion", { _context: "Trap action" }),
+  shotgun: t("Shotgun Blast", { _context: "Trap action" }),
+  blade: t("Blade", { _context: "Trap action" }),
+  caltrops: t("Caltrops", { _context: "Trap action" }),
+  tripwire: t("Tripwire", { _context: "Trap action" }),
+  pit: t("Pit", { _context: "Trap action" }),
+  lava: t("Lava", { _context: "Trap action" }),
+  snake: t("Snake Ambush", { _context: "Trap action" }),
+};
+
+const actionTitle = actionNames[item.action] || item.action;
+const constructingItems = data.constructsTrap(item.id);
+
+function dropCount(drop: Exclude<TrapDrop, string>): number | undefined {
+  if (!drop.item) return undefined;
+  const linkedItem = data.byIdMaybe("item", drop.item);
+  if (
+    linkedItem &&
+    drop.quantity != null &&
+    drop.charges != null &&
+    countsByCharges(linkedItem)
+  ) {
+    return drop.quantity * drop.charges;
+  }
+  return drop.quantity ?? drop.charges;
+}
+</script>
+
+<h1><ItemLink type="trap" id={item.id} link={false} /></h1>
+
+<section>
+  <dl>
+    {#if item.action}
+      <dt>{t("Action", { _context })}</dt>
+      <dd>{actionTitle}</dd>
+    {/if}
+
+    {#if item.always_invisible}
+      <dt>{t("Always Invisible", { _context })}</dt>
+      <dd>{t("Yes")}</dd>
+    {/if}
+
+    <dt>{t("Visibility", { _context })}</dt>
+    <dd>
+      {item.visibility < 0
+        ? t("Always visible", { _context })
+        : item.visibility}
+    </dd>
+
+    <dt>{t("Avoidance", { _context })}</dt>
+    <dd>{item.avoidance}</dd>
+
+    <dt>{t("Difficulty", { _context })}</dt>
+    <dd>{item.difficulty}</dd>
+
+    {#if item.benign}
+      <dt>{t("Benign", { _context })}</dt>
+      <dd>{t("Yes")}</dd>
+    {/if}
+
+    {#if item.trigger_weight}
+      <dt>{t("Trigger Weight", { _context })}</dt>
+      <dd>{item.trigger_weight}</dd>
+    {/if}
+
+    {#if item.remove_on_trigger}
+      <dt>{t("Remove on trigger", { _context })}</dt>
+      <dd>{t("Yes")}</dd>
+    {/if}
+
+    {#if item.trap_radius && item.trap_radius > 0}
+      <dt>{t("Trap Radius", { _context })}</dt>
+      <dd>{item.trap_radius}</dd>
+    {/if}
+
+    {#if item.funnel_radius && item.funnel_radius > 0}
+      <dt>{t("Funnel Radius", { _context })}</dt>
+      <dd>{item.funnel_radius} {t("mm", { _context })}</dd>
+    {/if}
+
+    {#if item.comfort && item.comfort !== 0}
+      <dt>{t("Comfort", { _context })}</dt>
+      <dd>{item.comfort}</dd>
+    {/if}
+
+    {#if item.floor_bedding_warmth && item.floor_bedding_warmth !== 0}
+      <dt>{t("Floor Bedding Warmth", { _context })}</dt>
+      <dd>{item.floor_bedding_warmth}</dd>
+    {/if}
+
+    {#if item.drops && item.drops.length > 0}
+      <dt>{t("Disarm drops", { _context })}</dt>
+      <dd>
+        <ul class="comma-separated">
+          {#each item.drops as drop}
+            <li>
+              {#if typeof drop === "string"}
+                <ItemLink type="item" id={drop} />
+              {:else if drop.item}
+                <ItemLink type="item" id={drop.item} count={dropCount(drop)} />
+              {/if}
+            </li>
+          {/each}
+        </ul>
+      </dd>
+    {/if}
+
+    {#if item.trigger_items && item.trigger_items.length > 0}
+      <dt>{t("Trigger drops", { _context })}</dt>
+      <dd>
+        <ul class="comma-separated">
+          {#each item.trigger_items as drop}
+            <li>
+              {#if typeof drop === "string"}
+                <ItemLink type="item" id={drop} />
+              {:else if drop.item}
+                <ItemLink type="item" id={drop.item} count={dropCount(drop)} />
+              {/if}
+            </li>
+          {/each}
+        </ul>
+      </dd>
+    {/if}
+  </dl>
+</section>
+
+{#if constructingItems.length}
+  <section>
+    <h2>{t("Construction", { _context })}</h2>
+    <LimitedList items={constructingItems}>
+      {#snippet children({ item: constructionItem })}
+        <ItemLink type="item" id={constructionItem.id} />
+      {/snippet}
+    </LimitedList>
+  </section>
+{/if}

--- a/src/types/Trap.test.ts
+++ b/src/types/Trap.test.ts
@@ -1,0 +1,194 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { render } from "@testing-library/svelte";
+import { describe, expect, it } from "vitest";
+import WithData from "../WithData.svelte";
+import { CBNData } from "../data";
+import Trap from "./Trap.svelte";
+
+describe("Trap", () => {
+  it("renders a basic trap showing names, stats and action", () => {
+    const data = new CBNData([
+      {
+        type: "trap",
+        id: "tr_crossbow",
+        name: "crossbow trap",
+        visibility: 5,
+        avoidance: 4,
+        difficulty: 0,
+        action: "crossbow",
+      },
+      {
+        type: "item",
+        id: "crossbow",
+        name: "crossbow",
+      },
+    ]);
+
+    const { getByText } = render(WithData, {
+      Component: Trap,
+      data,
+      item: data.byId("trap", "tr_crossbow"),
+    });
+
+    expect(getByText("Visibility")).toBeTruthy();
+    expect(getByText("5")).toBeTruthy();
+    expect(getByText("Avoidance")).toBeTruthy();
+    expect(getByText("4")).toBeTruthy();
+    expect(getByText("Difficulty")).toBeTruthy();
+    expect(getByText("0")).toBeTruthy();
+
+    expect(getByText("Action")).toBeTruthy();
+    expect(getByText("Crossbow Shot")).toBeTruthy();
+  });
+
+  it("shows the Benign property", () => {
+    const data = new CBNData([
+      {
+        type: "trap",
+        id: "tr_funnel",
+        name: "funnel",
+        visibility: -1,
+        avoidance: 0,
+        difficulty: 0,
+        action: "none",
+        benign: true,
+      },
+    ]);
+
+    const { getByText } = render(WithData, {
+      Component: Trap,
+      data,
+      item: data.byId("trap", "tr_funnel"),
+    });
+
+    expect(getByText("Always visible")).toBeTruthy();
+    expect(getByText("Benign")).toBeTruthy();
+  });
+
+  it("shows the drops list correctly", () => {
+    const data = new CBNData([
+      {
+        type: "trap",
+        id: "tr_nailboard",
+        name: "spiked board",
+        visibility: 1,
+        avoidance: 6,
+        difficulty: 0,
+        action: "board",
+        drops: ["board_trap"],
+      },
+      {
+        type: "item",
+        id: "board_trap",
+        name: "board trap",
+      },
+    ]);
+
+    const { getByText } = render(WithData, {
+      Component: Trap,
+      data,
+      item: data.byId("trap", "tr_nailboard"),
+    });
+
+    expect(getByText("Disarm drops")).toBeTruthy();
+    expect(getByText("board trap")).toBeTruthy();
+  });
+
+  it("shows the Remove on Trigger property and trigger_items", () => {
+    const data = new CBNData([
+      {
+        type: "trap",
+        id: "tr_beartrap",
+        name: "bear trap",
+        visibility: 2,
+        avoidance: 3,
+        difficulty: 5,
+        action: "beartrap",
+        remove_on_trigger: true,
+        trigger_items: ["beartrap_item"],
+      },
+      {
+        type: "item",
+        id: "beartrap_item",
+        name: "bear trap item",
+      },
+    ]);
+
+    const { getByText } = render(WithData, {
+      Component: Trap,
+      data,
+      item: data.byId("trap", "tr_beartrap"),
+    });
+
+    expect(getByText("Remove on trigger")).toBeTruthy();
+    expect(getByText("Trigger drops")).toBeTruthy();
+    expect(getByText("bear trap item")).toBeTruthy();
+  });
+
+  it("shows construction sources and trap-specific state", () => {
+    const data = new CBNData([
+      {
+        type: "trap",
+        id: "tr_bubblewrap",
+        name: "bubble wrap",
+        visibility: 0,
+        avoidance: 8,
+        difficulty: 0,
+        action: "bubble",
+        always_invisible: true,
+        trap_radius: 1,
+      },
+      {
+        type: "GENERIC",
+        id: "bubblewrap",
+        name: "bubble wrap sheet",
+        use_action: {
+          type: "place_trap",
+          trap: "tr_bubblewrap",
+        },
+      },
+    ]);
+
+    const { getByText } = render(WithData, {
+      Component: Trap,
+      data,
+      item: data.byId("trap", "tr_bubblewrap"),
+    });
+
+    expect(getByText("Always Invisible")).toBeTruthy();
+    expect(getByText("Trap Radius")).toBeTruthy();
+    expect(getByText("Construction")).toBeTruthy();
+    expect(getByText("bubble wrap sheet")).toBeTruthy();
+  });
+
+  it("preserves quantity when count-by-charges drops specify quantity and charges", () => {
+    const data = new CBNData([
+      {
+        type: "trap",
+        id: "tr_charge_drop",
+        name: "charge drop trap",
+        visibility: 1,
+        avoidance: 1,
+        difficulty: 1,
+        action: "none",
+        trigger_items: [{ item: "ration", quantity: 2, charges: 3 }],
+      },
+      {
+        type: "COMESTIBLE",
+        id: "ration",
+        name: "ration",
+      },
+    ]);
+
+    const { getByText } = render(WithData, {
+      Component: Trap,
+      data,
+      item: data.byId("trap", "tr_charge_drop"),
+    });
+
+    expect(getByText("ration")).toBeTruthy();
+    expect(getByText("(6)")).toBeTruthy();
+  });
+});

--- a/src/types/item/DisarmTrap.svelte
+++ b/src/types/item/DisarmTrap.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+import { t } from "@transifex/native";
+
+import { getContext, untrack } from "svelte";
+import type { CBNData } from "../../data";
+import LimitedList from "../../LimitedList.svelte";
+import type { Trap } from "../../types";
+import ItemLink from "../ItemLink.svelte";
+
+interface Props {
+  item_id: string;
+}
+
+let { item_id: sourceItemId }: Props = $props();
+const item_id = untrack(() => sourceItemId);
+
+const data = getContext<CBNData>("data");
+
+const traps = data.disarmTrap(item_id) as Trap[];
+</script>
+
+{#if traps.length}
+  <section>
+    <h2>{t("Disarmed From", { _context: "Obtaining" })}</h2>
+    <LimitedList items={traps}>
+      {#snippet children({ item: trap })}
+        <ItemLink id={trap.id} type="trap" />
+      {/snippet}
+    </LimitedList>
+  </section>
+{/if}

--- a/src/types/item/DisarmTrap.test.ts
+++ b/src/types/item/DisarmTrap.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { render } from "@testing-library/svelte";
+
+import WithData from "../../WithData.svelte";
+import { CBNData } from "../../data";
+import DisarmTrap from "./DisarmTrap.svelte";
+import { describe, expect, it } from "vitest";
+
+describe("the disarm trap section", () => {
+  it("shows traps that can drop an item when disarmed", () => {
+    const data = new CBNData([
+      {
+        type: "GENERIC",
+        id: "fake_item",
+        name: "fake item",
+      },
+      {
+        type: "trap",
+        id: "tr_fake_string_drop",
+        name: "string drop trap",
+        drops: ["fake_item"],
+      },
+      {
+        type: "trap",
+        id: "tr_fake_object_drop",
+        name: "object drop trap",
+        drops: [{ item: "fake_item", quantity: 2 }],
+      },
+    ]);
+
+    const { getByText } = render(WithData, {
+      Component: DisarmTrap,
+      data,
+      item_id: "fake_item",
+    });
+
+    expect(getByText("Disarmed From")).toBeTruthy();
+    expect(getByText("string drop trap")).toBeTruthy();
+    expect(getByText("object drop trap")).toBeTruthy();
+  });
+});

--- a/src/types/item/ItemSymbol.svelte
+++ b/src/types/item/ItemSymbol.svelte
@@ -50,9 +50,14 @@ let color = $derived(
 );
 
 function typeHasTile(item: any): boolean {
-  return ["item", "monster", "terrain", "furniture", "vehicle_part"].includes(
-    mapType(item.type),
-  );
+  return [
+    "item",
+    "monster",
+    "terrain",
+    "furniture",
+    "vehicle_part",
+    "trap",
+  ].includes(mapType(item.type));
 }
 
 function colorFromBgcolor(


### PR DESCRIPTION
## Summary
- add trap pages, routing, search indexing, translated labels, and SEO stats
- introduce typed trap data, a dedicated `Trap` component, and tile/icon support for traps
- show trap disarm sources on item pages and add reverse lookup for trap construction via `place_trap` use actions
- include trap URLs in the generated sitemap and add focused trap/disarm tests

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm vitest run src/types/Trap.test.ts src/types/item/DisarmTrap.test.ts --no-color`
- `pnpm gen:sitemap`