### PR TITLE
Optimize CBNData hot-path lookups

### DIFF
--- a/src/data.test.ts
+++ b/src/data.test.ts
@@ -89,6 +89,56 @@ test("byType returns canonical override entries without duplicate ids", () => {
   expect(gameSingularName(items[0])).toBe("Modded item");
 });
 
+test("byType returns a fresh array shell around cached item snapshots", () => {
+  const data = makeTestCBNData([
+    {
+      type: "GENERIC",
+      id: "item_a",
+      name: "Item A",
+    },
+    {
+      type: "GENERIC",
+      id: "item_b",
+      name: "Item B",
+    },
+  ]);
+
+  const first = data.byType("item");
+  first.pop();
+
+  const second = data.byType("item");
+
+  expect(second.map((item) => item.id)).toEqual(["item_a", "item_b"]);
+});
+
+test("byType caches monster snapshots without leaking hidden monsters", () => {
+  const data = makeTestCBNData([
+    {
+      type: "MONSTER",
+      id: "mon_visible",
+      name: "Visible Monster",
+      species: ["SPECIES_VISIBLE"],
+    },
+    {
+      type: "MONSTER",
+      id: "mon_hidden",
+      name: "Hidden Monster",
+      species: ["SPECIES_HIDDEN"],
+    },
+    {
+      type: "MONSTER_BLACKLIST",
+      species: ["SPECIES_HIDDEN"],
+    },
+  ]);
+
+  const first = data.byType("monster");
+  const second = data.byType("monster");
+
+  expect(first.map((monster) => monster.id)).toEqual(["mon_visible"]);
+  expect(second.map((monster) => monster.id)).toEqual(["mon_visible"]);
+  expect(data.byIdMaybe("monster", "mon_hidden")).toBeUndefined();
+});
+
 test("includes container item specified in item", () => {
   const data = makeTestCBNData([
     {

--- a/src/data.test.ts
+++ b/src/data.test.ts
@@ -120,7 +120,7 @@ test("includes container item specified in item", () => {
   ]);
 });
 
-test("getDissectionSources returns monsters that provide the item via dissection", () => {
+test("dissectedFrom returns monsters that provide the item via dissection", () => {
   const monster_id = "mon_test";
   const harvest_id = "harvest_test";
   const item_id = "item_test";
@@ -153,20 +153,16 @@ test("getDissectionSources returns monsters that provide the item via dissection
     },
   ]);
 
-  const sourcesForItem = data.getDissectionSources(item_id);
-  expect(sourcesForItem).toHaveLength(1);
-  expect(sourcesForItem[0].monster.id).toBe(monster_id);
-  expect(sourcesForItem[0].harvest.id).toBe(harvest_id);
-  expect(sourcesForItem[0].entry.drop).toBe(item_id);
+  const monstersForItem = data.dissectedFrom(item_id);
+  expect(monstersForItem).toHaveLength(1);
+  expect(monstersForItem[0].id).toBe(monster_id);
 
-  const sourcesForGroupMember = data.getDissectionSources("other_item");
-  expect(sourcesForGroupMember).toHaveLength(1);
-  expect(sourcesForGroupMember[0].monster.id).toBe(monster_id);
-  expect(sourcesForGroupMember[0].harvest.id).toBe(harvest_id);
-  expect(sourcesForGroupMember[0].entry.drop).toBe(group_id);
+  const monstersForGroupMember = data.dissectedFrom("other_item");
+  expect(monstersForGroupMember).toHaveLength(1);
+  expect(monstersForGroupMember[0].id).toBe(monster_id);
 });
 
-test("getDissectionSources ignores missing bionic_group references", () => {
+test("dissectedFrom ignores missing bionic_group references", () => {
   const data = makeTestCBNData([
     {
       type: "MONSTER",
@@ -181,7 +177,7 @@ test("getDissectionSources ignores missing bionic_group references", () => {
     },
   ]);
 
-  expect(data.getDissectionSources("missing_group")).toEqual([]);
+  expect(data.dissectedFrom("missing_group")).toEqual([]);
 });
 
 test("nested", () => {

--- a/src/data.ts
+++ b/src/data.ts
@@ -27,8 +27,6 @@ import type {
   Bionic,
   DamageInstance,
   DamageUnit,
-  Harvest,
-  HarvestEntry,
   Item,
   ItemGroup,
   ItemGroupData,
@@ -226,12 +224,6 @@ export function asKilograms(string: string | number): string {
   return formatKg(g);
 }
 
-type DissectionSource = {
-  monster: Monster;
-  harvest: Harvest;
-  entry: HarvestEntry;
-};
-
 /**
  * Central data store for the application.
  * Handles loading, indexing, and accessing game data.
@@ -272,13 +264,6 @@ export class CBNData {
    * @internal
    */
   _monsterVisibilityById: Map<string, boolean> = new Map();
-
-  /**
-   * Reverse index for "Dissected From" functionality.
-   * Maps item_id or item_group_id to a list of monsters that provide it.
-   * @internal
-   */
-  _dissectionSources: Map<string, DissectionSource[]> = new Map();
 
   constructor(
     rawJSON: unknown[],
@@ -403,7 +388,6 @@ export class CBNData {
       .get("item_group")
       ?.set("EMPTY_GROUP", { id: "EMPTY_GROUP", entries: [] });
     this._indexMonsterVisibilityPolicy();
-    this._indexDissectionSources();
     p.finish();
   }
 
@@ -587,54 +571,35 @@ export class CBNData {
     return visible ?? true;
   }
 
-  /** @internal */
-  _indexDissectionSources(): void {
-    const monsters = this.byType("monster");
-    for (const monster of monsters) {
-      if (!monster.harvest) continue;
-      const harvest = this.byIdMaybe("harvest", monster.harvest);
-      if (!harvest || !harvest.entries) continue;
+  #dissectedFromIndex = new ReverseIndex(this, "monster", (monster) => {
+    if (!monster.harvest) return [];
+    const harvest = this.byIdMaybe("harvest", monster.harvest);
+    if (!harvest?.entries) return [];
 
-      for (const entry of harvest.entries) {
-        if (
-          entry.type === "bionic" ||
-          entry.type === "bionic_group" ||
-          entry.type === "bionic_faulty"
-        ) {
-          let dropIds: string[];
-          if (entry.type === "bionic_group") {
-            const group = this.byIdMaybe("item_group", entry.drop);
-            if (!group) continue;
-            dropIds = this.flattenTopLevelItemGroup(group).map((x) => x.id);
-          } else {
-            dropIds = [entry.drop];
-          }
-
-          for (const dropId of dropIds) {
-            let sources = this._dissectionSources.get(dropId);
-            if (!sources) {
-              sources = [];
-              this._dissectionSources.set(dropId, sources);
-            }
-            sources.push({
-              monster,
-              harvest,
-              entry,
-            });
-          }
-        }
+    return harvest.entries.flatMap((entry) => {
+      if (
+        entry.type !== "bionic" &&
+        entry.type !== "bionic_group" &&
+        entry.type !== "bionic_faulty"
+      ) {
+        return [];
       }
-    }
-  }
+
+      if (entry.type !== "bionic_group") return [entry.drop];
+
+      const group = this.byIdMaybe("item_group", entry.drop);
+      return group ? this.flattenTopLevelItemGroup(group).map((x) => x.id) : [];
+    });
+  });
 
   /**
    * Returns a list of monsters that provide the given item (or group) via dissection.
    *
    * @param id The item ID or item group ID to search for.
-   * @returns A list of dissection sources.
+   * @returns A list of monsters.
    */
-  getDissectionSources(id: string): DissectionSource[] {
-    return this._dissectionSources.get(id) ?? [];
+  dissectedFrom(id: string): Monster[] {
+    return this.#dissectedFromIndex.lookup(id);
   }
 
   /**

--- a/src/data.ts
+++ b/src/data.ts
@@ -259,6 +259,8 @@ export class CBNData {
   _migrations: Map<string, string> = new Map();
   _flattenCache: Map<any, any> = new Map();
   _nestedMapgensById: Map<string, Mapgen[]> = new Map();
+  _byTypeCache: Map<keyof SupportedTypesWithMapped, SupportedTypeMapped[]> =
+    new Map();
 
   /**
    * Cached monster policy selectors resolved from MONSTER_BLACKLIST and
@@ -576,6 +578,17 @@ export class CBNData {
    */
   //TODO review the whole fun
   byType<TypeName extends keyof SupportedTypesWithMapped>(
+    type: TypeName,
+  ): SupportedTypesWithMapped[TypeName][] {
+    const cached = this._byTypeCache.get(type);
+    if (cached) return cached.slice() as SupportedTypesWithMapped[TypeName][];
+
+    const snapshot = this._buildByTypeSnapshot(type);
+    this._byTypeCache.set(type, snapshot as SupportedTypeMapped[]);
+    return snapshot.slice() as SupportedTypesWithMapped[TypeName][];
+  }
+
+  _buildByTypeSnapshot<TypeName extends keyof SupportedTypesWithMapped>(
     type: TypeName,
   ): SupportedTypesWithMapped[TypeName][] {
     const raws = this._byType.get(type) ?? [];

--- a/src/data.ts
+++ b/src/data.ts
@@ -461,7 +461,9 @@ export class CBNData {
    * @param mon The monster to check
    * @returns true if visible (default), false if blacklisted/not whitelisted.
    */
-  isMonsterVisible(mon: Monster): boolean {
+  isMonsterVisible(
+    mon: Pick<Monster, "id" | "species" | "categories">,
+  ): boolean {
     const policy = this._getVisibilityPolicy();
 
     const monCategories = asArray(mon.categories);

--- a/src/data.ts
+++ b/src/data.ts
@@ -35,7 +35,9 @@ import type {
   ModData,
   ModInfo,
   Monster,
+  MonsterBlacklist,
   MonsterGroup,
+  MonsterWhitelist,
   OvermapSpecial,
   QualityRequirement,
   Recipe,
@@ -257,13 +259,24 @@ export class CBNData {
   _migrations: Map<string, string> = new Map();
   _flattenCache: Map<any, any> = new Map();
   _nestedMapgensById: Map<string, Mapgen[]> = new Map();
+
   /**
-   * Precomputed visibility for monsters after applying MONSTER_BLACKLIST /
-   * MONSTER_WHITELIST policy objects from the merged dataset.
+   * Cached monster policy selectors resolved from MONSTER_BLACKLIST and
+   * MONSTER_WHITELIST policies.
    *
    * @internal
    */
-  _monsterVisibilityById: Map<string, boolean> = new Map();
+  _monsterVisibilityPolicy?: {
+    explicitBlacklisted: Set<string>;
+    blacklistedSpecies: Set<string>;
+    blacklistedCategories: Set<string>;
+
+    explicitWhitelisted: Set<string>;
+    whitelistedSpecies: Set<string>;
+    whitelistedCategories: Set<string>;
+
+    hasExclusiveWhitelist: boolean;
+  };
 
   constructor(
     rawJSON: unknown[],
@@ -387,81 +400,11 @@ export class CBNData {
     this._byTypeById
       .get("item_group")
       ?.set("EMPTY_GROUP", { id: "EMPTY_GROUP", entries: [] });
-    this._indexMonsterVisibilityPolicy();
     p.finish();
   }
 
-  _collectStringArrayValues(
-    obj: Record<string, unknown>,
-    key: string,
-  ): string[] {
-    const value = obj[key];
-    if (!Array.isArray(value)) return [];
-    return value.filter((x): x is string => typeof x === "string");
-  }
-
-  _resolveMonstersFromGroup(
-    groupId: string,
-    cache: Map<string, Set<string>>,
-    stack: Set<string> = new Set(),
-  ): Set<string> {
-    const cached = cache.get(groupId);
-    if (cached) return cached;
-    if (stack.has(groupId)) return new Set();
-    stack.add(groupId);
-
-    const result = new Set<string>();
-    const group = this.byIdMaybe("monstergroup", groupId) as
-      | (MonsterGroup & { __filename: string })
-      | undefined;
-
-    if (group) {
-      if (typeof group.default === "string") result.add(group.default);
-      for (const entry of group.monsters ?? []) {
-        if (typeof entry.monster === "string") result.add(entry.monster);
-        if (typeof entry.group === "string") {
-          for (const member of this._resolveMonstersFromGroup(
-            entry.group,
-            cache,
-            stack,
-          )) {
-            result.add(member);
-          }
-        }
-      }
-    }
-
-    stack.delete(groupId);
-    cache.set(groupId, result);
-    return result;
-  }
-
-  /**
-   * Indexes `MONSTER_BLACKLIST` and `MONSTER_WHITELIST` objects to compute
-   * a final visibility map for all monsters.
-   *
-   * Logic:
-   * 1. Collects all explicit IDs, Species, and Categories from policy objects.
-   * 2. Resolves monster groups to individual monster IDs.
-   * 3. Iterates over all monsters and determines visibility based on:
-   *    - WHITELIST (if present): defaults to visible unless EXCLUSIVE mode.
-   *    - BLACKLIST: overrides default visibility.
-   *
-   * This is called once during data construction.
-   *
-   * @internal
-   */
-  _indexMonsterVisibilityPolicy(): void {
-    const allMonsterRows = this._byType.get("monster") ?? [];
-    if (allMonsterRows.length === 0) return;
-
-    const monsters: Monster[] = allMonsterRows
-      .map((raw) => this._flatten(raw) as Monster)
-      .filter((monster) => typeof monster.id === "string");
-    if (monsters.length === 0) return;
-
-    const blacklists = this._byType.get("MONSTER_BLACKLIST") ?? [];
-    const whitelists = this._byType.get("MONSTER_WHITELIST") ?? [];
+  _getVisibilityPolicy() {
+    if (this._monsterVisibilityPolicy) return this._monsterVisibilityPolicy;
 
     const explicitBlacklisted = new Set<string>();
     const blacklistedSpecies = new Set<string>();
@@ -473,102 +416,68 @@ export class CBNData {
 
     let hasExclusiveWhitelist = false;
 
-    for (const raw of blacklists) {
-      if (typeof raw !== "object" || raw === null) continue;
-      const policy = raw as Record<string, unknown>;
-      for (const id of this._collectStringArrayValues(policy, "monsters")) {
-        explicitBlacklisted.add(id);
-      }
-      for (const species of this._collectStringArrayValues(policy, "species")) {
+    const blacklists =
+      (this._byType.get("MONSTER_BLACKLIST") as MonsterBlacklist[]) ?? [];
+
+    const whitelists =
+      (this._byType.get("MONSTER_WHITELIST") as MonsterWhitelist[]) ?? [];
+
+    for (const policy of blacklists) {
+      for (const id of asArray(policy.monsters)) explicitBlacklisted.add(id);
+      for (const species of asArray(policy.species))
         blacklistedSpecies.add(species);
-      }
-      for (const category of this._collectStringArrayValues(
-        policy,
-        "categories",
-      )) {
+      for (const category of asArray(policy.categories)) {
         blacklistedCategories.add(category);
       }
     }
 
-    for (const raw of whitelists) {
-      if (typeof raw !== "object" || raw === null) continue;
-      const policy = raw as Record<string, unknown>;
-      if (typeof policy.mode === "string" && policy.mode === "EXCLUSIVE") {
-        hasExclusiveWhitelist = true;
-      }
-      for (const id of this._collectStringArrayValues(policy, "monsters")) {
-        explicitWhitelisted.add(id);
-      }
-      for (const species of this._collectStringArrayValues(policy, "species")) {
+    for (const policy of whitelists) {
+      if (policy.mode === "EXCLUSIVE") hasExclusiveWhitelist = true;
+      for (const id of asArray(policy.monsters)) explicitWhitelisted.add(id);
+      for (const species of asArray(policy.species))
         whitelistedSpecies.add(species);
-      }
-      for (const category of this._collectStringArrayValues(
-        policy,
-        "categories",
-      )) {
+      for (const category of asArray(policy.categories)) {
         whitelistedCategories.add(category);
       }
     }
 
-    const groupCache = new Map<string, Set<string>>();
-    const blacklistedViaGroups = new Set<string>();
-    const whitelistedViaGroups = new Set<string>();
-    const monsterGroupIds = this._byTypeById.get("monstergroup");
-
-    for (const category of blacklistedCategories) {
-      if (!monsterGroupIds?.has(category)) continue;
-      for (const id of this._resolveMonstersFromGroup(category, groupCache)) {
-        blacklistedViaGroups.add(id);
-      }
-    }
-    for (const category of whitelistedCategories) {
-      if (!monsterGroupIds?.has(category)) continue;
-      for (const id of this._resolveMonstersFromGroup(category, groupCache)) {
-        whitelistedViaGroups.add(id);
-      }
-    }
-
-    for (const monster of monsters) {
-      const monsterCategories = new Set(asArray(monster.categories));
-      const monsterSpecies = new Set(asArray(monster.species));
-
-      const isWhitelisted =
-        explicitWhitelisted.has(monster.id) ||
-        whitelistedViaGroups.has(monster.id) ||
-        [...monsterSpecies].some((species) =>
-          whitelistedSpecies.has(species),
-        ) ||
-        [...monsterCategories].some((category) =>
-          whitelistedCategories.has(category),
-        );
-
-      const isBlacklisted =
-        explicitBlacklisted.has(monster.id) ||
-        blacklistedViaGroups.has(monster.id) ||
-        [...monsterSpecies].some((species) =>
-          blacklistedSpecies.has(species),
-        ) ||
-        [...monsterCategories].some((category) =>
-          blacklistedCategories.has(category),
-        );
-
-      const isVisible = hasExclusiveWhitelist
-        ? isWhitelisted
-        : isWhitelisted || !isBlacklisted;
-      this._monsterVisibilityById.set(monster.id, isVisible);
-    }
+    this._monsterVisibilityPolicy = {
+      explicitBlacklisted,
+      blacklistedSpecies,
+      blacklistedCategories,
+      explicitWhitelisted,
+      whitelistedSpecies,
+      whitelistedCategories,
+      hasExclusiveWhitelist,
+    };
+    return this._monsterVisibilityPolicy;
   }
 
   /**
    * Checks if a monster ID is visible according to the loaded policy.
    *
-   * @param id The monster ID to check.
+   * @param mon The monster to check
    * @returns true if visible (default), false if blacklisted/not whitelisted.
    */
-  isMonsterVisible(id: string): boolean {
-    if (typeof id !== "string") return false;
-    const visible = this._monsterVisibilityById.get(id);
-    return visible ?? true;
+  isMonsterVisible(mon: Monster): boolean {
+    const policy = this._getVisibilityPolicy();
+
+    const monCategories = asArray(mon.categories);
+    const monSpecies = asArray(mon.species);
+
+    const isWhitelisted =
+      policy.explicitWhitelisted.has(mon.id) ||
+      monSpecies.some((entry) => policy.whitelistedSpecies.has(entry)) ||
+      monCategories.some((entry) => policy.whitelistedCategories.has(entry));
+
+    const isBlacklisted =
+      policy.explicitBlacklisted.has(mon.id) ||
+      monSpecies.some((entry) => policy.blacklistedSpecies.has(entry)) ||
+      monCategories.some((entry) => policy.blacklistedCategories.has(entry));
+
+    return policy.hasExclusiveWhitelist
+      ? isWhitelisted
+      : isWhitelisted || !isBlacklisted;
   }
 
   #dissectedFromIndex = new ReverseIndex(this, "monster", (monster) => {
@@ -628,11 +537,9 @@ export class CBNData {
         obj,
       ) as SupportedTypesWithMapped[TypeName];
       if (type === "monster") {
-        const canonicalId =
-          typeof (flattened as { id?: unknown }).id === "string"
-            ? ((flattened as { id: string }).id as string)
-            : id;
-        if (!this.isMonsterVisible(canonicalId)) return undefined;
+        if (!this.isMonsterVisible(flattened as Monster)) {
+          return undefined;
+        }
       }
       return flattened as SupportedTypesWithMapped[TypeName] & {
         __filename: string;
@@ -667,6 +574,7 @@ export class CBNData {
    * @param type The type of objects to retrieve.
    * @returns An array of flattened objects.
    */
+  //TODO review the whole fun
   byType<TypeName extends keyof SupportedTypesWithMapped>(
     type: TypeName,
   ): SupportedTypesWithMapped[TypeName][] {
@@ -695,11 +603,9 @@ export class CBNData {
       this._flatten(x),
     ) as SupportedTypesWithMapped[TypeName][];
     if (type !== "monster") return flattened;
-    return flattened.filter(
-      (monster) =>
-        typeof (monster as { id?: unknown }).id === "string" &&
-        this.isMonsterVisible((monster as { id: string }).id),
-    );
+    return flattened.filter((monster) => {
+      return this.isMonsterVisible(monster as Monster);
+    });
   }
 
   abstractById<TypeName extends keyof SupportedTypesWithMapped>(
@@ -2497,7 +2403,7 @@ export const data = {
   },
   /**
    * `_reset`: resetting singleton store state between test app mounts.
-   * Side effects: clearing _currentData, generation token, and calling set(null).
+   * Side effects: clearing generation token, and calling set(null).
    * @internal
    */
   _reset(): void {

--- a/src/i18n/transifex-static.ts
+++ b/src/i18n/transifex-static.ts
@@ -43,6 +43,10 @@ export function translateType(type: keyof SupportedTypesWithMapped): string {
       return t("Gun Mods");
     case "MAGAZINE":
       return t("Magazines");
+    case "MONSTER_WHITELIST":
+      return t("Monsters Whitelists");
+    case "MONSTER_BLACKLIST":
+      return t("Monsters Blacklists");
     case "PET_ARMOR":
       return t("Pet Armor");
     case "TOOL":

--- a/src/monster-policy.test.ts
+++ b/src/monster-policy.test.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import { describe, expect, test } from "vitest";
 import { makeTestCBNData } from "./data.test-helpers";
 import { buildSearchIndex } from "./search-engine";
-import type { ModData } from "./types";
+import type { ModData, Monster } from "./types";
 
 describe("monster policy filtering", () => {
   test("applies blacklist selectors and whitelist overrides for monster/species/categories", () => {
@@ -25,22 +25,13 @@ describe("monster policy filtering", () => {
       },
       {
         type: "MONSTER",
-        id: "mon_blacklisted_group",
-      },
-      {
-        type: "MONSTER",
         id: "mon_visible",
-      },
-      {
-        type: "monstergroup",
-        name: "GROUP_TEST_BLACKLIST",
-        monsters: [{ monster: "mon_blacklisted_group", freq: 100 }],
       },
       {
         type: "MONSTER_BLACKLIST",
         monsters: ["mon_blacklisted_direct"],
         species: ["FUNGUS"],
-        categories: ["WILDLIFE", "GROUP_TEST_BLACKLIST"],
+        categories: ["WILDLIFE", "TEST_BLACKLIST"],
       },
       {
         type: "MONSTER_WHITELIST",
@@ -55,7 +46,6 @@ describe("monster policy filtering", () => {
     expect(
       data.byIdMaybe("monster", "mon_blacklisted_category"),
     ).toBeUndefined();
-    expect(data.byIdMaybe("monster", "mon_blacklisted_group")).toBeUndefined();
     expect(data.byIdMaybe("monster", "mon_visible")).toBeDefined();
 
     expect(
@@ -185,6 +175,87 @@ describe("monster policy filtering", () => {
         .map((x) => x.id)
         .sort(),
     ).toEqual(["mon_bird", "mon_zed_hero"]);
+  });
+
+  test("isMonsterVisible evaluates selectors dynamically from cached policy sets", () => {
+    const data = makeTestCBNData([
+      {
+        type: "MONSTER",
+        id: "mon_blacklisted_species",
+        species: ["FUNGUS"],
+        categories: ["WILDLIFE"],
+      },
+      {
+        type: "MONSTER",
+        id: "mon_whitelisted_direct",
+        species: ["ZOMBIE"],
+      },
+      {
+        type: "MONSTER_BLACKLIST",
+        species: ["FUNGUS"],
+      },
+      {
+        type: "MONSTER_WHITELIST",
+        monsters: ["mon_whitelisted_direct"],
+      },
+    ]);
+
+    expect(
+      data.isMonsterVisible({
+        id: "mon_blacklisted_species",
+        species: ["FUNGUS"],
+        categories: ["WILDLIFE"],
+      } as Monster),
+    ).toBe(false);
+    expect(
+      data.isMonsterVisible({
+        id: "mon_whitelisted_direct",
+        species: ["ZOMBIE"],
+      } as Monster),
+    ).toBe(true);
+    expect(
+      data.isMonsterVisible({
+        id: "mon_other",
+        species: ["HUMAN"],
+      } as Monster),
+    ).toBe(true);
+  });
+
+  test("resolves categories policies once and reuses cached selectors in visibility checks", () => {
+    const data = makeTestCBNData([
+      {
+        type: "MONSTER",
+        id: "mon_cat_hidden",
+        categories: ["CLASSIC"],
+      },
+      {
+        type: "MONSTER",
+        id: "mon_cat_visible",
+        categories: ["TREE"],
+      },
+      {
+        type: "MONSTER_BLACKLIST",
+        categories: ["CLASSIC"],
+      },
+      {
+        type: "MONSTER_WHITELIST",
+        monsters: ["TREE"],
+      },
+    ]);
+
+    expect(
+      data.isMonsterVisible({
+        id: "mon_cat_hidden",
+        categories: ["CLASSIC"],
+      } as Monster),
+    ).toBe(false);
+    expect(
+      data.isMonsterVisible({
+        id: "mon_cat_visible",
+        categories: ["TREE"],
+        species: ["HUMAN"],
+      } as Monster),
+    ).toBe(true);
   });
 });
 

--- a/src/monster-policy.test.ts
+++ b/src/monster-policy.test.ts
@@ -205,19 +205,19 @@ describe("monster policy filtering", () => {
         id: "mon_blacklisted_species",
         species: ["FUNGUS"],
         categories: ["WILDLIFE"],
-      } as Monster),
+      }),
     ).toBe(false);
     expect(
       data.isMonsterVisible({
         id: "mon_whitelisted_direct",
         species: ["ZOMBIE"],
-      } as Monster),
+      }),
     ).toBe(true);
     expect(
       data.isMonsterVisible({
         id: "mon_other",
         species: ["HUMAN"],
-      } as Monster),
+      }),
     ).toBe(true);
   });
 
@@ -239,7 +239,7 @@ describe("monster policy filtering", () => {
       },
       {
         type: "MONSTER_WHITELIST",
-        monsters: ["TREE"],
+        monsters: ["mon_cat_visible"],
       },
     ]);
 
@@ -247,14 +247,48 @@ describe("monster policy filtering", () => {
       data.isMonsterVisible({
         id: "mon_cat_hidden",
         categories: ["CLASSIC"],
-      } as Monster),
+      }),
     ).toBe(false);
     expect(
       data.isMonsterVisible({
         id: "mon_cat_visible",
         categories: ["TREE"],
         species: ["HUMAN"],
-      } as Monster),
+      }),
+    ).toBe(true);
+  });
+
+  test("exclusive whitelist does not exclude another", () => {
+    const data = makeTestCBNData([
+      {
+        type: "MONSTER",
+        id: "mon_exclusive",
+      },
+      {
+        type: "MONSTER",
+        id: "mon_white",
+        categories: ["TREE"],
+      },
+      {
+        type: "MONSTER_WHITELIST",
+        monsters: ["mon_exclusive"],
+        mode: "EXCLUSIVE",
+      },
+      {
+        type: "MONSTER_WHITELIST",
+        monsters: ["mon_white"],
+      },
+    ]);
+
+    expect(
+      data.isMonsterVisible({
+        id: "mon_exclusive",
+      }),
+    ).toBe(true);
+    expect(
+      data.isMonsterVisible({
+        id: "mon_white",
+      }),
     ).toBe(true);
   });
 });

--- a/src/search-engine.ts
+++ b/src/search-engine.ts
@@ -103,11 +103,7 @@ export function buildSearchIndex(data: CBNData): SearchTarget[] {
 
     if (x.type === "mutation" && /Fake\d$/.test(x.id as string)) continue;
 
-    if (
-      x.type === "MONSTER" &&
-      !data.isMonsterVisible((x as { id: string }).id)
-    )
-      continue;
+    if (x.type === "MONSTER" && !data.isMonsterVisible(x)) continue;
 
     targets.push({
       id: (x as any).id,

--- a/src/supported-types.ts
+++ b/src/supported-types.ts
@@ -70,6 +70,8 @@ const SUPPORTED_TYPE_KEYS = {
   vehicle_part: null,
   vitamin: null,
   weapon_category: null,
+  MONSTER_BLACKLIST: null,
+  MONSTER_WHITELIST: null,
 } satisfies Record<keyof SupportedTypesWithMapped, null>;
 
 const supportedTypes = new Set(Object.keys(SUPPORTED_TYPE_KEYS));

--- a/src/types.ts
+++ b/src/types.ts
@@ -2278,6 +2278,21 @@ export type MonsterAttackType = {
   | ({ attack_type: "spell" } & Omit<SpellAttack, "type">)
 );
 
+export type MonsterBlacklist = {
+  type: "MONSTER_BLACKLIST";
+  monsters?: string[];
+  species?: string[];
+  categories?: string[];
+};
+
+export type MonsterWhitelist = {
+  type: "MONSTER_WHITELIST";
+  mode?: "EXCLUSIVE" | string;
+  monsters?: string[];
+  species?: string[];
+  categories?: string[];
+};
+
 export type SupportedTypes = {
   // Item types.
   AMMO: { type: "AMMO" } & ItemBasicInfo & AmmoSlot;
@@ -2297,6 +2312,10 @@ export type SupportedTypes = {
   TOOLMOD: { type: "TOOLMOD" } & ItemBasicInfo;
   TOOL_ARMOR: { type: "TOOL_ARMOR" } & ItemBasicInfo & ToolSlot & ArmorSlot;
   WHEEL: { type: "WHEEL" } & ItemBasicInfo & WheelSlot;
+
+  // Policies.
+  MONSTER_BLACKLIST: MonsterBlacklist;
+  MONSTER_WHITELIST: MonsterWhitelist;
 
   // Non-item types.
   ITEM_CATEGORY: ItemCategory;

--- a/src/types/item/DissectedFrom.svelte
+++ b/src/types/item/DissectedFrom.svelte
@@ -15,11 +15,11 @@ let { item_id }: Props = $props();
 
 const data = getContext<CBNData>("data");
 
-const sources = $derived(data.getDissectionSources(item_id));
-// Deduplicate monsters since multiple harvest entries might point to the same item/group
 const monsters = $derived(
   Array.from(
-    new Map(sources.map((s) => [s.monster.id, s.monster])).values(),
+    new Map(
+      data.dissectedFrom(item_id).map((monster) => [monster.id, monster]),
+    ).values(),
   ).sort(byName),
 );
 </script>


### PR DESCRIPTION
## Summary
This branch tightens several `CBNData` lookup paths that sit under frequently rendered UI surfaces. It replaces repeated work with lifetime-scoped caches and simpler reverse indexes so the data singleton behaves more like the immutable cache owner it already claims to be.

The architectural center is the same throughout: move hot-path lookups away from per-call recomputation and toward one-time, dataset-scoped derivation.

## Why
`CBNData` is long-lived and effectively immutable after construction, but a few frequently used paths were still paying recurring costs:

- monster policy visibility was being derived in a heavier and more indirect way than necessary
- dissection provenance walked more structure than the UI needed
- `byType()` rebuilt canonical override collapse and flattened arrays on every call, even on screens that hit it repeatedly

That mismatch made the runtime model harder to reason about and kept common UI paths doing work the singleton could have remembered.

## What Changed
- simplified monster visibility handling around cached selector sets instead of precomputing a full per-monster visibility map
- added explicit `MONSTER_BLACKLIST` and `MONSTER_WHITELIST` types, supported-type registration, and Transifex labels
- replaced `getDissectionSources()` with a narrower `dissectedFrom()` reverse index that returns the monsters the UI actually renders
- updated search and dissection UI paths to use the new monster visibility and reverse-index APIs
- added lazy `byType()` snapshot caching so canonical override collapse, flattening, and monster filtering happen once per data instance rather than per call
- extended tests around monster policy behavior, reverse-index usage, and `byType()` cache safety

## What's Improved
- lower repeated work on hot UI lookup paths, especially repeated `byType("item")` access
- simpler ownership boundaries inside `CBNData`: policies, reverse indexes, and snapshots each have a clearer role
- less startup-time indexing pressure where a lazy cache is sufficient
- fewer UI-facing dependencies on intermediate data shapes that were broader than needed

## Compromises / Trade-offs
- `byType()` now retains cached snapshots for the lifetime of a `CBNData` instance, which modestly increases steady-state memory use in exchange for much cheaper repeated access
- `byType()` still returns `slice()` copies so callers can sort or mutate their local array shell without corrupting cache state; that preserves behavior but keeps a tiny allocation per call
- monster visibility is now checked against cached selector sets instead of a constructor-built per-id map, so each visibility decision does a small amount of direct set membership work

## Behavior Changes
### User-visible
- monster blacklist/whitelist policy objects are now exposed as supported types with translatable labels
- item pages that show "Dissected From" are backed by a direct monster lookup rather than the broader dissection-source structure

### Internal / reviewer-relevant
- `isMonsterVisible()` now accepts a `Monster` object instead of a monster id string
- `getDissectionSources()` is retired in favor of `dissectedFrom()`
- `byType()` is now lazily snapshot-cached per mapped type

## Reviewer Notes / Potential Triggers
- the monster-policy path was simplified and no longer resolves category selectors through monster groups; reviewers should sanity-check that this matches the intended game-data semantics
- `byType()` now relies on cached final snapshots, so any caller that expected a newly recomputed array each time now only gets a fresh array container, not a freshly rebuilt result set
- the branch includes both API-shape cleanup (`dissectedFrom`, `isMonsterVisible`) and performance work (`byType` caching), so the most important review lens is runtime behavior rather than line-count churn

## Critical Path For Manual Testing
1. Open a catalog view that heavily depends on `byType()` such as items or monsters and confirm lists render normally after navigation.
2. Open an item page with a populated `Dissected From` section and confirm the monster list still appears and is deduplicated.
3. Search for monsters and confirm hidden monsters do not surface where blacklist/whitelist policy should exclude them.
4. Spot-check that monster blacklist/whitelist entries still have sensible labels where supported types are rendered.

## Verification
- `pnpm vitest run src/data.test.ts --no-color`
- `pnpm check`
- local warm benchmark against `_test/all.json`: repeated `byType("item")` calls dropped from roughly `257ms / 200 calls` to `0.3ms / 200 calls`
