### PR TITLE
Improve compatibility with mods

### DIFF
--- a/src/PageMeta.svelte
+++ b/src/PageMeta.svelte
@@ -5,7 +5,7 @@ import { gameSingular, gameSingularName } from "./i18n/game-locale";
 import { RUNNING_MODE } from "./utils/env";
 import { UI_GUIDE_NAME } from "./constants";
 import { buildURL } from "./routing.svelte";
-import { data } from "./data";
+import { data, normalizeDamageInstance } from "./data";
 import type {
   ArmorSlot,
   DamageInstance,
@@ -154,25 +154,18 @@ const formatQualities = (qualities?: [string, number][]): string | null => {
   return formatted.length > 0 ? formatted.join(", ") : null;
 };
 
-const primaryDamageUnit = (
-  damage?: DamageInstance | number,
-): DamageUnit | null => {
+const primaryDamageUnit = (damage?: DamageInstance): DamageUnit | null => {
   if (damage == null) return null;
-  if (typeof damage === "number") {
-    return {
-      damage_type: "bullet",
-      amount: damage,
-      armor_penetration: 0,
-    };
-  }
-  if (Array.isArray(damage)) return damage[0] ?? null;
+  const normalized = normalizeDamageInstance(damage)[0];
+  if (normalized) return normalized;
   if (
     typeof damage === "object" &&
-    "values" in damage &&
-    Array.isArray(damage.values)
-  )
-    return damage.values[0] ?? null;
-  if (typeof damage === "object") return damage as DamageUnit;
+    !Array.isArray(damage) &&
+    damage !== null &&
+    !("values" in damage)
+  ) {
+    return damage as DamageUnit;
+  }
   return null;
 };
 

--- a/src/data.ts
+++ b/src/data.ts
@@ -1854,10 +1854,11 @@ export const countsByCharges = (item: any): boolean => {
 };
 
 export function normalizeDamageInstance(
-  damageInstance: DamageInstance | number | null | undefined,
+  damageInstance: DamageInstance | undefined,
 ): DamageUnit[] {
   if (typeof damageInstance === "number") {
-    return [{ damage_type: "bash", amount: damageInstance }];
+    // BN's legacy scalar damage_instance loader maps numeric values to DT_STAB.
+    return [{ damage_type: "stab", amount: damageInstance }];
   }
   if (!damageInstance || typeof damageInstance !== "object") {
     return [];
@@ -1993,6 +1994,9 @@ function applyProportionalDamageInstance(
 }
 
 export function cloneDamageInstance(di: DamageInstance): DamageInstance {
+  if (typeof di === "number") {
+    return di;
+  }
   if (Array.isArray(di)) {
     return di.map((u) => ({ ...u }));
   } else if ("values" in di) {

--- a/src/data.ts
+++ b/src/data.ts
@@ -874,6 +874,11 @@ export class CBNData {
       ret.parts = [...parentProps.parts, ...obj.parts];
     }
     for (const k of Object.keys(ret.relative ?? {})) {
+      if (k === "melee_damage" && ret.type === "MONSTER") {
+        // Monster melee_damage is loaded directly in BN, not via assign(), so
+        // relative modifiers do not apply.
+        continue;
+      }
       if (typeof ret.relative[k] === "number") {
         if (k === "weight") {
           ret[k] = (parseMass(ret[k]) ?? 0) + ret.relative[k];
@@ -906,6 +911,11 @@ export class CBNData {
     }
     delete ret.relative;
     for (const k of Object.keys(ret.proportional ?? {})) {
+      if (k === "melee_damage" && ret.type === "MONSTER") {
+        // Monster melee_damage is loaded directly in BN, not via assign(), so
+        // proportional modifiers do not apply.
+        continue;
+      }
       if (typeof ret.proportional[k] === "number") {
         if (k === "attack_cost" && !(k in ret)) ret[k] = 100;
         if (typeof ret[k] === "string") {

--- a/src/mod-schema.test.ts
+++ b/src/mod-schema.test.ts
@@ -3,39 +3,11 @@ import * as fs from "fs";
 import * as util from "util";
 import type { ValidateFunction } from "ajv";
 import Ajv from "ajv";
-import { describe, expect, test } from "vitest";
+import { expect, test, describe } from "vitest";
+import { makeTestCBNData } from "./data.test-helpers";
 import type { ModData, ModInfo } from "./types";
 
 type ModsMap = Record<string, ModData>;
-type EntityKey = `${string}::${string}`; // "type::id"
-type EntityWithSource = {
-  entity: any;
-  __source__: string[];
-};
-
-// Local type mappings (same as data.ts but accepting any string)
-const typeMappings = new Map<string, string>([
-  ["AMMO", "item"],
-  ["GUN", "item"],
-  ["ARMOR", "item"],
-  ["PET_ARMOR", "item"],
-  ["TOOL", "item"],
-  ["TOOLMOD", "item"],
-  ["TOOL_ARMOR", "item"],
-  ["BOOK", "item"],
-  ["COMESTIBLE", "item"],
-  ["CONTAINER", "item"],
-  ["ENGINE", "item"],
-  ["WHEEL", "item"],
-  ["GUNMOD", "item"],
-  ["MAGAZINE", "item"],
-  ["BATTERY", "item"],
-  ["GENERIC", "item"],
-  ["BIONIC_ITEM", "item"],
-  ["MONSTER", "monster"],
-]);
-
-const mapType = (type: string): string => typeMappings.get(type) ?? type;
 
 declare global {
   namespace jest {
@@ -49,7 +21,7 @@ expect.extend({
   toMatchSchema(obj: any, schema: ValidateFunction) {
     const valid = schema(obj);
     const errors = schema.errors?.slice();
-    const filename = obj.__filename;
+    const filename = findFilename(obj);
     return {
       pass: valid,
       message: () => {
@@ -66,22 +38,6 @@ expect.extend({
     };
   },
 });
-
-// Load all data
-const allMods = JSON.parse(
-  fs.readFileSync(__dirname + "/../_test/all_mods.json", "utf8"),
-) as unknown;
-
-const baseGameData = JSON.parse(
-  fs.readFileSync(__dirname + "/../_test/all.json", "utf8"),
-).data as any[];
-
-function asModsMap(value: unknown): ModsMap {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error("all_mods.json must be a top-level object map");
-  }
-  return value as ModsMap;
-}
 
 const program = TJS.createGenerator({
   tsconfig: __dirname + "/../tsconfig.json",
@@ -107,42 +63,30 @@ const schemasByType = new Map(
   }),
 );
 
-// ============================================================================
-// Simplified Copy-From Resolver
-// ============================================================================
+const allMods = JSON.parse(
+  fs.readFileSync(__dirname + "/../_test/all_mods.json", "utf8"),
+) as unknown;
+const baseGameData = JSON.parse(
+  fs.readFileSync(__dirname + "/../_test/all.json", "utf8"),
+).data as any[];
 
-/**
- * Get entity ID (handles different ID patterns in game data)
- * Returns first ID for display/primary key purposes
- */
+function asModsMap(value: unknown): ModsMap {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("all_mods.json must be a top-level object map");
+  }
+  return value as ModsMap;
+}
+
 function getEntityId(entity: any): string | undefined {
-  const id = entity.id ?? entity.abstract ?? entity.result;
-  if (Array.isArray(id)) return id[0];
-  return id ?? undefined;
+  if (entity.id) return entity.id;
+  if (entity.result) return entity.result;
+  if (entity.om_terrain) return JSON.stringify(entity.om_terrain);
 }
 
-/**
- * Get ALL entity IDs (handles array IDs in game data)
- * Used for building lookup so each ID variant can be found
- */
-function getEntityIds(entity: any): string[] {
-  const id = entity.id ?? entity.abstract ?? entity.result;
-  if (!id) return [];
-  if (Array.isArray(id)) return id;
-  return [id];
+function findFilename(obj: any): string | undefined {
+  return typeof obj?.__filename === "string" ? obj.__filename : undefined;
 }
 
-/**
- * Create lookup key for entity
- */
-function makeKey(type: string, id: string): EntityKey {
-  return `${mapType(type)}::${id}`;
-}
-
-/**
- * Resolve mod dependencies into load order (topological sort)
- * Returns array of mod IDs in order: dependencies first, target mod last
- */
 function resolveDependencyChain(
   modsMap: ModsMap,
   targetModId: string,
@@ -158,7 +102,7 @@ function resolveDependencyChain(
   const chain: string[] = [];
 
   for (const depId of deps) {
-    if (depId === "bn") continue; // Skip core, handled separately
+    if (depId === "bn") continue;
     chain.push(...resolveDependencyChain(modsMap, depId, visited));
   }
 
@@ -166,210 +110,113 @@ function resolveDependencyChain(
   return chain;
 }
 
-/**
- * Recursive copy-from resolver - resolves entire inheritance chain
- * Ignores inheritance verbs (relative, proportional, extend, delete)
- */
-function applyCopyFrom(
-  entity: any,
-  lookup: Map<EntityKey, EntityWithSource>,
-  visited = new Set<string>(),
-): any {
-  if (!("copy-from" in entity)) {
-    return { ...entity };
-  }
+type TestCase = [id: string, obj: any];
+type TypeGroups = Map<string, TestCase[]>; // type -> [[id, obj], ...]
+type ModGroups = Map<string, TypeGroups>; // modId -> TypeGroups
 
-  const parentId = entity["copy-from"];
-  const entityType = mapType(entity.type);
-  const parentKey = makeKey(entityType, parentId);
+function buildModSchemaCases(modsMap: ModsMap): ModGroups {
+  const groupedCases: ModGroups = new Map();
 
-  // Cycle detection
-  if (visited.has(parentKey)) {
-    console.warn(`Cycle detected in copy-from chain: ${parentKey}`);
-    return { ...entity };
-  }
-  visited.add(parentKey);
+  const sortedModIds = Object.keys(modsMap)
+    .filter((id) => id !== "bn")
+    .sort();
 
-  const parentEntry = lookup.get(parentKey);
+  for (const modId of sortedModIds) {
+    const modData = modsMap[modId];
+    if (!modData) continue;
 
-  if (!parentEntry) {
-    // Parent not found - return entity as-is (will fail schema validation if incomplete)
-    return { ...entity };
-  }
+    // Expensive setup per mod
+    const dependencyChain = resolveDependencyChain(modsMap, modId, new Set());
+    const mergedData = [
+      ...baseGameData,
+      ...dependencyChain.flatMap((cid) => modsMap[cid]?.data ?? []),
+    ];
+    const data = makeTestCBNData(mergedData, {
+      activeMods: dependencyChain,
+      rawModsJSON: modsMap,
+    });
 
-  // Recursively resolve parent's copy-from chain first
-  const resolvedParent = applyCopyFrom(parentEntry.entity, lookup, visited);
+    const typeMap: TypeGroups = new Map();
 
-  // Shallow merge: resolved parent properties first, then child overrides
-  const { abstract, ...parentProps } = resolvedParent;
-  return { ...parentProps, ...entity };
-}
+    for (const entity of modData.data as any[]) {
+      const id = getEntityId(entity);
+      if (!id || !schemasByType.has(entity.type)) continue;
 
-/**
- * Build lookup map with all entities, resolving copy-from inheritance
- * as each mod is loaded in dependency order.
- */
-function buildEntityLookup(modsMap: ModsMap): Map<EntityKey, EntityWithSource> {
-  const lookup = new Map<EntityKey, EntityWithSource>();
+      const flattened = data._flatten(entity);
 
-  // 1. Load base game data (source: 'bn')
-  // Register each ID separately for array-ID entities
-  for (const entity of baseGameData) {
-    const ids = getEntityIds(entity);
-    if (ids.length === 0) continue;
-
-    const entry: EntityWithSource = {
-      entity: { ...entity },
-      __source__: ["bn"],
-    };
-    for (const id of ids) {
-      const key = makeKey(entity.type, id);
-      lookup.set(key, entry);
-    }
-  }
-
-  // 2. Get all unique mod IDs and their dependency chains
-  const allModIds = Object.keys(modsMap).filter((id) => id !== "bn");
-  const processedMods = new Set<string>();
-
-  // Process all mods, respecting dependencies
-  for (const modId of allModIds) {
-    const chain = resolveDependencyChain(modsMap, modId, new Set());
-
-    for (const chainModId of chain) {
-      if (processedMods.has(chainModId)) continue;
-      processedMods.add(chainModId);
-
-      const modData = modsMap[chainModId];
-      if (!modData) continue;
-
-      for (const entity of modData.data as any[]) {
-        const id = getEntityId(entity);
-        if (!id) continue;
-
-        const key = makeKey(entity.type, id);
-        const existing = lookup.get(key);
-
-        // Handle self-referential copy-from (mod copies from same ID in base)
-        // We need to resolve BEFORE updating the lookup
-        let resolved: any;
-        const copyFromId = entity["copy-from"];
-        if (copyFromId && copyFromId === id && existing) {
-          // Self-reference: merge with existing entry (the one being overridden)
-          const resolvedExisting = applyCopyFrom(existing.entity, lookup);
-          const { abstract, ...existingProps } = resolvedExisting;
-          resolved = { ...existingProps, ...entity };
-        } else {
-          resolved = applyCopyFrom(entity, lookup);
-        }
-
-        if (existing) {
-          // Mod overriding existing entity
-          lookup.set(key, {
-            entity: resolved,
-            __source__: [...existing.__source__, chainModId],
-          });
-        } else {
-          // New entity from mod
-          lookup.set(key, {
-            entity: resolved,
-            __source__: [chainModId],
-          });
-        }
+      if (!typeMap.has(entity.type)) {
+        typeMap.set(entity.type, []);
       }
+
+      typeMap.get(entity.type)!.push([
+        id,
+        {
+          ...flattened,
+          __filename: entity.__filename ?? flattened.__filename,
+        },
+      ]);
+    }
+
+    if (typeMap.size > 0) {
+      groupedCases.set(modId, typeMap);
     }
   }
 
-  return lookup;
+  return groupedCases;
 }
-
-// ============================================================================
-// Build test data
-// ============================================================================
 
 const modsMap = asModsMap(allMods);
-const entityLookup = buildEntityLookup(modsMap);
+const groupedCases = buildModSchemaCases(modsMap);
 
-// Collect all mod objects for validation (only entities touched by each mod)
-const allModObjects: Array<[string, string, string, any]> = [];
-
-for (const [key, value] of entityLookup.entries()) {
-  const entity = value.entity;
-  const type = mapType(entity.type);
-
-  // Skip base-only entities (not touched by any mod)
-  const modSources = value.__source__.filter((s) => s !== "bn");
-  if (modSources.length === 0) continue;
-
-  // Skip types we don't have schemas for
-  if (!schemasByType.has(type)) continue;
-
-  // Skip abstract entities - they're templates, not complete entities
-  if (entity.abstract) continue;
-
-  const id = getEntityId(entity);
-  if (!id) continue;
-
-  // Add test case for the last mod that touched this entity
-  const lastMod = modSources[modSources.length - 1];
-  allModObjects.push([lastMod, type, id, entity]);
-}
-
-const skipped = new Set<string>([]);
-
-// ============================================================================
-// Tests
-// ============================================================================
-
-describe("all_mods schema", () => {
-  test("uses top-level map with {info,data} entries", () => {
-    const modsMap = asModsMap(allMods);
-    for (const [modId, entry] of Object.entries(modsMap)) {
-      expect(entry).toBeTypeOf("object");
-      expect(entry.info).toBeTypeOf("object");
-      expect(Array.isArray(entry.data)).toBe(true);
-      expect((entry.info as ModInfo).type).toBe("MOD_INFO");
-      expect((entry.info as ModInfo).id).toBe(modId);
-    }
-  });
-
-  test("has at most one core mod", () => {
-    const modsMap = asModsMap(allMods);
-    const coreCount = Object.values(modsMap).filter(
-      (entry) => (entry.info as ModInfo).core,
-    ).length;
-    expect(coreCount).toBeLessThanOrEqual(1);
-  });
-
-  test("requires id/name/description/category/dependencies for non-core mods", () => {
-    const modsMap = asModsMap(allMods);
-    for (const entry of Object.values(modsMap)) {
-      const info = entry.info as ModInfo;
-      expect(typeof info.id).toBe("string");
-      expect(info.name).toBeDefined();
-      expect(info.description).toBeDefined();
-      expect(info.category).toBeDefined();
-      if (info.core) {
-        continue;
-      }
-      expect(Array.isArray(info.dependencies)).toBe(true);
-    }
-  });
-
-  test("bn core mod is allowed to omit dependencies", () => {
-    const modsMap = asModsMap(allMods);
-    const bn = modsMap.bn;
-    expect(bn).toBeDefined();
-    expect((bn.info as ModInfo).core).toBe(true);
-  });
+test("all_mods uses top-level map with {info,data} entries", () => {
+  const modsMap = asModsMap(allMods);
+  for (const [modId, entry] of Object.entries(modsMap)) {
+    expect(entry).toBeTypeOf("object");
+    expect(entry.info).toBeTypeOf("object");
+    expect(Array.isArray(entry.data)).toBe(true);
+    expect((entry.info as ModInfo).type).toBe("MOD_INFO");
+    expect((entry.info as ModInfo).id).toBe(modId);
+  }
 });
 
-test.each(allModObjects)(
-  "mod %s: schema matches %s %s",
-  (modId, type, objId, obj) => {
-    if (skipped.has(JSON.stringify(objId))) {
-      return;
+test("all_mods has at most one core mod", () => {
+  const modsMap = asModsMap(allMods);
+  const coreCount = Object.values(modsMap).filter(
+    (entry) => (entry.info as ModInfo).core,
+  ).length;
+  expect(coreCount).toBeLessThanOrEqual(1);
+});
+
+test("all_mods requires id/name/description/category/dependencies for non-core mods", () => {
+  const modsMap = asModsMap(allMods);
+  for (const entry of Object.values(modsMap)) {
+    const info = entry.info as ModInfo;
+    expect(typeof info.id).toBe("string");
+    expect(info.name).toBeDefined();
+    expect(info.description).toBeDefined();
+    expect(info.category).toBeDefined();
+    if (info.core) {
+      continue;
     }
-    expect(obj).toMatchSchema(schemasByType.get(type)!);
-  },
-);
+    expect(Array.isArray(info.dependencies)).toBe(true);
+  }
+});
+
+test("bn core mod is allowed to omit dependencies", () => {
+  const modsMap = asModsMap(allMods);
+  const bn = modsMap.bn;
+  expect(bn).toBeDefined();
+  expect((bn.info as ModInfo).core).toBe(true);
+});
+
+for (const [modId, typeMap] of groupedCases) {
+  describe(`Mod: ${modId}`, () => {
+    for (const [type, cases] of typeMap) {
+      describe(`type: ${type}`, () => {
+        test.each(cases)("id:%s schema match", (id, obj) => {
+          expect(obj).toMatchSchema(schemasByType.get(type)!);
+        });
+      });
+    }
+  });
+}

--- a/src/mod-schema.test.ts
+++ b/src/mod-schema.test.ts
@@ -1,43 +1,11 @@
 import * as TJS from "ts-json-schema-generator";
 import * as fs from "fs";
-import * as util from "util";
-import type { ValidateFunction } from "ajv";
 import Ajv from "ajv";
 import { expect, test, describe } from "vitest";
 import { makeTestCBNData } from "./data.test-helpers";
 import type { ModData, ModInfo } from "./types";
 
 type ModsMap = Record<string, ModData>;
-
-declare global {
-  namespace jest {
-    interface Matchers<R> {
-      toMatchSchema(validate: ValidateFunction): R;
-    }
-  }
-}
-
-expect.extend({
-  toMatchSchema(obj: any, schema: ValidateFunction) {
-    const valid = schema(obj);
-    const errors = schema.errors?.slice();
-    const filename = findFilename(obj);
-    return {
-      pass: valid,
-      message: () => {
-        const errorMessages =
-          errors
-            ?.map(
-              (e) =>
-                `${e.instancePath} ${e.message}, but was ${util.inspect(e.data)}`,
-            )
-            .join("\n") ?? "";
-
-        return (filename ? `[File: ${filename}]\n` : "") + errorMessages;
-      },
-    };
-  },
-});
 
 const program = TJS.createGenerator({
   tsconfig: __dirname + "/../tsconfig.json",
@@ -81,10 +49,6 @@ function getEntityId(entity: any): string | undefined {
   if (entity.id) return entity.id;
   if (entity.result) return entity.result;
   if (entity.om_terrain) return JSON.stringify(entity.om_terrain);
-}
-
-function findFilename(obj: any): string | undefined {
-  return typeof obj?.__filename === "string" ? obj.__filename : undefined;
 }
 
 function resolveDependencyChain(

--- a/src/mods.test.ts
+++ b/src/mods.test.ts
@@ -141,6 +141,24 @@ describe("DinoMod regressions", () => {
     ).toBe(true);
   });
 
+  test("unsupported monster melee_damage modifiers are ignored", () => {
+    const coreJSON = JSON.parse(
+      fs.readFileSync(__dirname + "/../_test/all.json", "utf8"),
+    );
+    const modsJSON = JSON.parse(
+      fs.readFileSync(__dirname + "/../_test/all_mods.json", "utf8"),
+    ) as Record<string, { data: unknown[] }>;
+    const merged = [...coreJSON.data, ...modsJSON.DinoMod.data];
+    const loaded = makeTestCBNData(merged);
+
+    expect(
+      loaded.byId("monster", "mon_zosmoceratops_fungus").melee_damage,
+    ).toEqual([{ damage_type: "stab", amount: 15 }]);
+    expect(loaded.byId("monster", "mon_zriceratops_hulk").melee_damage).toEqual(
+      [{ damage_type: "stab", amount: 15 }],
+    );
+  });
+
   test("self copy-from overrides in DinoMod preserve base fields and apply extensions", () => {
     const coreJSON = JSON.parse(
       fs.readFileSync(__dirname + "/../_test/all.json", "utf8"),

--- a/src/mods.test.ts
+++ b/src/mods.test.ts
@@ -3,6 +3,14 @@ import { describe, expect, test } from "vitest";
 import { CBNData, data, normalizeDamageInstance } from "./data";
 import { makeTestCBNData } from "./data.test-helpers";
 
+describe("damage normalization", () => {
+  test("legacy scalar damage normalizes as stab damage", () => {
+    expect(normalizeDamageInstance(3)).toEqual([
+      { damage_type: "stab", amount: 3 },
+    ]);
+  });
+});
+
 describe("Mod merge ordering", () => {
   async function getLoadedData(): Promise<CBNData> {
     return await new Promise<CBNData>((resolve) => {

--- a/src/schema.test-matchers.ts
+++ b/src/schema.test-matchers.ts
@@ -44,17 +44,3 @@ expect.extend({
 function findFilename(obj: any): string | undefined {
   return typeof obj?.__filename === "string" ? obj.__filename : undefined;
 }
-
-//
-// const findFilename = (
-//   obj: any,
-//   parentMap: WeakMap<object, object | null>,
-// ): string | undefined => {
-//   let current: any = obj;
-//
-//   while (current) {
-//     if (current.__filename) return current.__filename;
-//     current = parentMap.get(current) || null; // Move up to parent
-//   }
-//   return undefined;
-// };

--- a/src/schema.test-matchers.ts
+++ b/src/schema.test-matchers.ts
@@ -2,11 +2,9 @@ import { expect } from "vitest";
 import type { ValidateFunction } from "ajv";
 import util from "util";
 
-declare global {
-  namespace jest {
-    interface Matchers<R> {
-      toMatchSchema(validate: ValidateFunction): R;
-    }
+declare module "vitest" {
+  interface Matchers<T = any> {
+    toMatchSchema(validate: ValidateFunction): T;
   }
 }
 

--- a/src/schema.test-matchers.ts
+++ b/src/schema.test-matchers.ts
@@ -1,0 +1,60 @@
+import { expect } from "vitest";
+import type { ValidateFunction } from "ajv";
+import util from "util";
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toMatchSchema(validate: ValidateFunction): R;
+    }
+  }
+}
+
+expect.extend({
+  toMatchSchema(obj: any, schema: ValidateFunction) {
+    const valid = schema(obj);
+    const errors = schema.errors?.slice();
+    const filename = findFilename(obj);
+
+    return {
+      pass: valid,
+      message: () => {
+        const errorMessages =
+          errors
+            ?.map(
+              (e) =>
+                `${e.instancePath} ${e.message}, but was ${util.inspect(e.data)}`,
+            )
+            .join("\n") ?? "";
+
+        return (
+          (filename ? `\n[Location: ${filename}]\n` : "") +
+          "\n[Validation errors:\n" +
+          errorMessages +
+          "\n]\n" +
+          "\n[Object:\n" +
+          util.inspect(obj) +
+          "\n]\n"
+        );
+      },
+    };
+  },
+});
+
+function findFilename(obj: any): string | undefined {
+  return typeof obj?.__filename === "string" ? obj.__filename : undefined;
+}
+
+//
+// const findFilename = (
+//   obj: any,
+//   parentMap: WeakMap<object, object | null>,
+// ): string | undefined => {
+//   let current: any = obj;
+//
+//   while (current) {
+//     if (current.__filename) return current.__filename;
+//     current = parentMap.get(current) || null; // Move up to parent
+//   }
+//   return undefined;
+// };

--- a/src/schema.test.ts
+++ b/src/schema.test.ts
@@ -38,35 +38,6 @@ const getEntityId = (x: any): string | undefined => {
   if (x.om_terrain) return JSON.stringify(x.om_terrain);
 };
 
-// const findFilename = (
-//   obj: any,
-//   parentMap: WeakMap<object, object | null>,
-// ): string | undefined => {
-//   let current: any = obj;
-//
-//   while (current) {
-//     if (current.__filename) return current.__filename;
-//     current = parentMap.get(current) || null; // Move up to parent
-//   }
-//   return undefined;
-// };
-//
-// // Create a parent tracking map before validation
-// const parentMap = new WeakMap<object, object | null>();
-//
-// const buildParentMap = (obj: any, parent: any = null) => {
-//   if (typeof obj !== "object" || obj === null) return;
-//   parentMap.set(obj, parent);
-//   for (const key in obj) {
-//     if (typeof obj[key] === "object" && obj[key] !== null) {
-//       buildParentMap(obj[key], obj);
-//     }
-//   }
-// };
-
-// Build parent-child relationships
-// buildParentMap(data.all());
-
 type TestCase = [id: string, obj: any];
 type TypeGroups = Map<string, TestCase[]>;
 

--- a/src/schema.test.ts
+++ b/src/schema.test.ts
@@ -65,7 +65,7 @@ const skipped = new Set<string>([]);
 for (const [type, cases] of groupedCases) {
   describe(`type: ${type}`, () => {
     test.each(cases)("id:%s schema match", (id, obj) => {
-      if (skipped.has(JSON.stringify(id))) {
+      if (skipped.has(id)) {
         return;
       }
       expect(obj).toMatchSchema(schemasByType.get(type)!);

--- a/src/schema.test.ts
+++ b/src/schema.test.ts
@@ -2,7 +2,7 @@ import * as TJS from "ts-json-schema-generator";
 import * as fs from "fs";
 import Ajv from "ajv";
 import { makeTestCBNData } from "./data.test-helpers";
-import { expect, test } from "vitest";
+import { expect, describe, test } from "vitest";
 
 const program = TJS.createGenerator({
   tsconfig: __dirname + "/../tsconfig.json",
@@ -32,7 +32,7 @@ const schemasByType = new Map(
 const data = makeTestCBNData(
   JSON.parse(fs.readFileSync(__dirname + "/../_test/all.json", "utf8")).data,
 );
-const id = (x: any) => {
+const getEntityId = (x: any): string | undefined => {
   if (x.id) return x.id;
   if (x.result) return x.result;
   if (x.om_terrain) return JSON.stringify(x.om_terrain);
@@ -67,18 +67,37 @@ const id = (x: any) => {
 // Build parent-child relationships
 // buildParentMap(data.all());
 
-const all = data
-  .all()
-  .filter((x) => id(x))
-  .filter((x) => schemasByType.has(x.type))
-  .map((x, i) => [x.type, id(x) ?? i, data._flatten(x)]);
+type TestCase = [id: string, obj: any];
+type TypeGroups = Map<string, TestCase[]>;
+
+function buildSchemaCases(): TypeGroups {
+  const groupedCases: TypeGroups = new Map();
+
+  for (const entity of data.all()) {
+    const id = getEntityId(entity);
+    if (!id || !schemasByType.has(entity.type)) continue;
+
+    if (!groupedCases.has(entity.type)) {
+      groupedCases.set(entity.type, []);
+    }
+
+    groupedCases.get(entity.type)!.push([id, data._flatten(entity)]);
+  }
+
+  return groupedCases;
+}
+
+const groupedCases = buildSchemaCases();
 
 const skipped = new Set<string>([]);
 
-test.each(all)("schema matches %s %s", (type, id, obj) => {
-  if (skipped.has(JSON.stringify(id))) {
-    //pending();
-    return;
-  }
-  expect(obj).toMatchSchema(schemasByType.get(type)!);
-});
+for (const [type, cases] of groupedCases) {
+  describe(`type: ${type}`, () => {
+    test.each(cases)("id:%s schema match", (id, obj) => {
+      if (skipped.has(JSON.stringify(id))) {
+        return;
+      }
+      expect(obj).toMatchSchema(schemasByType.get(type)!);
+    });
+  });
+}

--- a/src/schema.test.ts
+++ b/src/schema.test.ts
@@ -1,40 +1,8 @@
 import * as TJS from "ts-json-schema-generator";
 import * as fs from "fs";
-import * as util from "util";
-import type { ValidateFunction } from "ajv";
 import Ajv from "ajv";
 import { makeTestCBNData } from "./data.test-helpers";
 import { expect, test } from "vitest";
-
-declare global {
-  namespace jest {
-    interface Matchers<R> {
-      toMatchSchema(validate: ValidateFunction): R;
-    }
-  }
-}
-
-expect.extend({
-  toMatchSchema(obj: any, schema: ValidateFunction) {
-    const valid = schema(obj);
-    const errors = schema.errors?.slice();
-    const filename = findFilename(obj, parentMap);
-    return {
-      pass: valid,
-      message: () => {
-        const errorMessages =
-          errors
-            ?.map(
-              (e) =>
-                `${e.instancePath} ${e.message}, but was ${util.inspect(e.data)}`,
-            )
-            .join("\n") ?? "";
-
-        return (filename ? `[File: ${filename}]\n` : "") + errorMessages;
-      },
-    };
-  },
-});
 
 const program = TJS.createGenerator({
   tsconfig: __dirname + "/../tsconfig.json",
@@ -70,34 +38,34 @@ const id = (x: any) => {
   if (x.om_terrain) return JSON.stringify(x.om_terrain);
 };
 
-const findFilename = (
-  obj: any,
-  parentMap: WeakMap<object, object | null>,
-): string | undefined => {
-  let current: any = obj;
-
-  while (current) {
-    if (current.__filename) return current.__filename;
-    current = parentMap.get(current) || null; // Move up to parent
-  }
-  return undefined;
-};
-
-// Create a parent tracking map before validation
-const parentMap = new WeakMap<object, object | null>();
-
-const buildParentMap = (obj: any, parent: any = null) => {
-  if (typeof obj !== "object" || obj === null) return;
-  parentMap.set(obj, parent);
-  for (const key in obj) {
-    if (typeof obj[key] === "object" && obj[key] !== null) {
-      buildParentMap(obj[key], obj);
-    }
-  }
-};
+// const findFilename = (
+//   obj: any,
+//   parentMap: WeakMap<object, object | null>,
+// ): string | undefined => {
+//   let current: any = obj;
+//
+//   while (current) {
+//     if (current.__filename) return current.__filename;
+//     current = parentMap.get(current) || null; // Move up to parent
+//   }
+//   return undefined;
+// };
+//
+// // Create a parent tracking map before validation
+// const parentMap = new WeakMap<object, object | null>();
+//
+// const buildParentMap = (obj: any, parent: any = null) => {
+//   if (typeof obj !== "object" || obj === null) return;
+//   parentMap.set(obj, parent);
+//   for (const key in obj) {
+//     if (typeof obj[key] === "object" && obj[key] !== null) {
+//       buildParentMap(obj[key], obj);
+//     }
+//   }
+// };
 
 // Build parent-child relationships
-buildParentMap(data.all());
+// buildParentMap(data.all());
 
 const all = data
   .all()

--- a/src/types.ts
+++ b/src/types.ts
@@ -235,7 +235,8 @@ export type DamageUnit = {
 export type DamageInstance =
   | DamageUnit[]
   | { values: DamageUnit[] }
-  | DamageUnit;
+  | DamageUnit
+  | number; // Legacy scalar form loaded by BN assign.cpp as DT_STAB.
 
 export type GunSlot = {
   skill: string; // skill_id

--- a/src/types.ts
+++ b/src/types.ts
@@ -330,7 +330,7 @@ export type ComestibleSlot = {
     | "none";
   addiction_potential?: integer; // default 0
   calories?: integer;
-  vitamins?: [string, integer][];
+  vitamins?: ([string, integer] | [string, integer, integer])[];
   rot_spawn?: string; // mongroup_id
   rot_spawn_chance?: integer; // default 10
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1541,7 +1541,7 @@ export type Monster = {
   flags?: string[];
   harvest?: string; // harvest_id
   bodytype?: string;
-  species?: string[];
+  species?: string[] | string;
   speed?: number;
   melee_skill?: integer;
   melee_dice?: integer;

--- a/src/types.ts
+++ b/src/types.ts
@@ -682,7 +682,7 @@ export type ItemBasicInfo = {
     byproducts?: string[]; // item_id
   };
   ascii_picture?: string;
-  weapon_category?: string[]; // weapon_category_id
+  weapon_category?: string[] | string; // weapon_category_id
   use_action?:
     | string
     | UseFunction

--- a/src/types.ts
+++ b/src/types.ts
@@ -413,6 +413,7 @@ export type UseFunction =
   | HandCrankUseFunction
   | HolsterUseFunction
   | ItemActionUseFunction
+  | LearnSpellUseFunction
   | MessageUseFunction
   | MulticookerUseFunction
   | MusicPlayerUseFunction
@@ -607,6 +608,11 @@ export type MessageUseFunction = {
   type: "message";
   name?: Translation;
   message: Translation;
+};
+
+export type LearnSpellUseFunction = {
+  type: "learn_spell";
+  spells: string[]; // spell_id
 };
 
 export type PocketDimensionUseFunction = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -258,7 +258,7 @@ export type GunSlot = {
   ups_charges?: number; // int
   blackpowder_tolerance?: number; // int, default: 8
   min_cycle_recoil?: number; // int, default: 0
-  ammo_effects?: string[];
+  ammo_effects?: string | string[];
   ammo_to_fire?: number; // int, default: 1
 
   valid_mod_locations?: [string, number][]; // [gunmod_location, count]

--- a/src/types.ts
+++ b/src/types.ts
@@ -409,6 +409,7 @@ export type UseFunction =
   | DelayedTransformUseFunction
   | DimensionTravelUseFunction
   | DnaEditorUseFunction
+  | FlowerpotPlantUseFunction
   | GpsDeviceUseFunction
   | HandCrankUseFunction
   | HolsterUseFunction
@@ -585,6 +586,17 @@ export type ConsumeDrugUseFunction = {
   vitamins?: ([string, integer] | [string, integer, integer])[];
 
   used_up_item?: string;
+};
+
+export type FlowerpotPlantUseFunction = {
+  type: "flowerpot_plant";
+  stages: string[];
+  growth_rate?: number;
+  fert_boost?: number;
+  harvest_mult?: number;
+  seeds_per_use?: integer | [integer, integer];
+  fert_per_use?: integer | [integer, integer];
+  terrain?: string[];
 };
 
 export type RepairItemUseFunction = {

--- a/src/types/item/GunInfo.svelte
+++ b/src/types/item/GunInfo.svelte
@@ -3,7 +3,7 @@ import { t } from "@transifex/native";
 
 import type { DamageUnit, GunSlot, Item } from "../../types";
 import ThingLink from "../ThingLink.svelte";
-import { CBNData } from "../../data";
+import { CBNData, normalizeDamageInstance } from "../../data";
 import { getContext, untrack } from "svelte";
 import GunAmmoInfo from "./GunAmmoInfo.svelte";
 
@@ -40,28 +40,7 @@ function extractRangedDamage(): DamageUnit {
     armor_penetration: 0,
   };
 
-  if (Array.isArray(gunProps.ranged_damage)) {
-    return gunProps.ranged_damage[0];
-  }
-
-  if (typeof gunProps.ranged_damage === "number") {
-    return {
-      amount: gunProps.ranged_damage,
-      damage_type: "bullet",
-      armor_penetration: 0,
-    };
-  }
-
-  if (
-    gunProps.ranged_damage &&
-    typeof gunProps.ranged_damage === "object" &&
-    "values" in gunProps.ranged_damage &&
-    Array.isArray(gunProps.ranged_damage.values)
-  ) {
-    return gunProps.ranged_damage.values[0];
-  }
-
-  return (gunProps.ranged_damage as DamageUnit) ?? defaultDamage;
+  return normalizeDamageInstance(gunProps.ranged_damage)[0] ?? defaultDamage;
 }
 
 const ranged_damage = extractRangedDamage();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -255,7 +255,7 @@ export default defineConfig({
   // @ts-ignore
   test: {
     environment: "happy-dom",
-    setupFiles: ["src/test-setup.ts"],
+    setupFiles: ["src/test-setup.ts", "src/schema.test-matchers.ts"],
     execArgv: ["--max-old-space-size=3072"],
   },
 });


### PR DESCRIPTION
## Summary
- Add schema support for the mod data shapes currently present in fixtures, including `learn_spell`, `flowerpot_plant`, scalar gun ammo effects, and vitamin triples.
- Align damage handling with BN behavior for legacy scalar `ranged_damage` and preserve the narrow fallback paths used by gun/meta presentation.
- Prevent DinoMod monster `melee_damage` modifiers from being applied in `_flatten()` because BN loads that field directly rather than through `assign()`.

## Testing
- `pnpm vitest run src/mod-schema.test.ts src/mods.test.ts src/PageMeta.test.ts --no-color`
- `pnpm check`