### PR TITLE
Refactor requirement and tool list rendering into shared wrappers

### DIFF
--- a/src/assets/design.css
+++ b/src/assets/design.css
@@ -110,7 +110,6 @@ ul.comma-separated > li:not(:last-child)::after {
 }
 ul.comma-separated.or > li:last-child:not(:first-child)::before {
   content: "or";
-  margin-left: 0.5em;
   margin-right: 0.5em;
   vertical-align: middle;
 }

--- a/src/types/Construction.svelte
+++ b/src/types/Construction.svelte
@@ -2,6 +2,7 @@
 import { t } from "@transifex/native";
 import JSONView from "../JSONView.svelte";
 
+import RequirementsAndList from "./item/RequirementsAndList.svelte";
 import { getContext, untrack } from "svelte";
 import { CBNData } from "../data";
 import type { Construction, RequirementData } from "../types";
@@ -12,7 +13,8 @@ import {
 } from "./construction";
 import ThingLink from "./ThingLink.svelte";
 import RequirementDataTools from "./item/RequirementDataTools.svelte";
-import { i18n, gameSingular, gameSingularName } from "../i18n/game-locale";
+import { gameSingular, gameSingularName } from "../i18n/game-locale";
+import RequirementsOrList from "./item/RequirementsOrList.svelte";
 
 const data = getContext<CBNData>("data");
 const _context = "Construction";
@@ -61,6 +63,17 @@ if (construction.pre_flags)
       preFlags.push({ flag });
     } else preFlags.push(flag);
   }
+
+function sortComponentChoices(
+  componentChoices: { id: string; count: number }[],
+): { id: string; count: number }[] {
+  return [...componentChoices].sort(
+    (a, b) =>
+      gameSingularName(data.byId("item", a.id)).localeCompare(
+        gameSingularName(data.byId("item", b.id)),
+      ) || a.id.localeCompare(b.id),
+  );
+}
 </script>
 
 <section>
@@ -73,9 +86,13 @@ if (construction.pre_flags)
     <dt>{t("Required Skills")}</dt>
     <dd>
       {#if construction.required_skills?.length}
-        {#each construction.required_skills as [id, level], i}
-          <ThingLink type="skill" {id} showIcon={false} /> ({level}){#if i + 2 === construction.required_skills?.length}{" and "}{:else if i + 1 !== construction.required_skills?.length}{", "}{/if}
-        {/each}
+        <RequirementsAndList
+          items={construction.required_skills}
+          horizontal={true}>
+          {#snippet children({ item: [id, level] })}
+            <ThingLink type="skill" {id} showIcon={false} /> ({level})
+          {/snippet}
+        </RequirementsAndList>
       {:else}
         {t("none")}
       {/if}
@@ -115,15 +132,22 @@ if (construction.pre_flags)
     {#if components.length}
       <dt>{t("Components", { _context: "Requirement" })}</dt>
       <dd>
-        <ul class="no-bullets">
-          {#each components as componentChoices}
-            <li>
-              {#each componentChoices.map( (c) => ({ ...c, item: data.byId("item", c.id) }), ) as { id, count }, i}
-                {#if i !== 0}{i18n.__(" OR ")}{/if}
-                <ThingLink {id} {count} type="item" showIcon={false} />
-              {/each}
-            </li>{/each}
-        </ul>
+        <RequirementsAndList items={components}>
+          {#snippet children({ item: componentChoices })}
+            {@const sortedChoices = sortComponentChoices(componentChoices)}
+            <RequirementsOrList
+              items={sortedChoices}
+              hideLabelWhenSingle={true}>
+              {#snippet children({ item: component })}
+                <ThingLink
+                  id={component.id}
+                  count={component.count}
+                  type="item"
+                  showIcon={false} />
+              {/snippet}
+            </RequirementsOrList>
+          {/snippet}
+        </RequirementsAndList>
       </dd>
     {/if}
     {#if byproducts.length}

--- a/src/types/Fault.svelte
+++ b/src/types/Fault.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
+import RequirementsAndList from "./item/RequirementsAndList.svelte";
 import type { CBNData } from "../data";
 import ThingLink from "./ThingLink.svelte";
 import { getContext, untrack } from "svelte";
 import type { Fault, RequirementData } from "../types";
 import { t } from "@transifex/native";
 import RequirementDataTools from "./item/RequirementDataTools.svelte";
-import { i18n, gameSingular, gameSingularName } from "../i18n/game-locale";
+import { gameSingular, gameSingularName } from "../i18n/game-locale";
+import RequirementsOrList from "./item/RequirementsOrList.svelte";
 
 const data = getContext<CBNData>("data");
 const _context = "Fault";
@@ -34,6 +36,17 @@ const mendingMethods = (item.mending_methods ?? []).map((mm) => {
   );
   return { mending_method: mm, components, requirement };
 });
+
+function sortComponentChoices(
+  componentChoices: { id: string; count: number }[],
+): { id: string; count: number }[] {
+  return [...componentChoices].sort(
+    (a, b) =>
+      gameSingularName(data.byId("item", a.id)).localeCompare(
+        gameSingularName(data.byId("item", b.id)),
+      ) || a.id.localeCompare(b.id),
+  );
+}
 </script>
 
 <h1>{t("Fault")}: {gameSingularName(item)}</h1>
@@ -76,16 +89,22 @@ const mendingMethods = (item.mending_methods ?? []).map((mm) => {
       {#if components.length}
         <dt>{t("Components", { _context: "Requirement" })}</dt>
         <dd>
-          <ul>
-            {#each components as componentChoices}
-              <li>
-                {#each componentChoices.map( (c) => ({ ...c, item: data.byId("item", c.id) }), ) as { id, count }, i}
-                  {#if i !== 0}{i18n.__(" OR ")}{/if}
-                  <ThingLink {id} {count} type="item" showIcon={false} />
-                {/each}
-              </li>
-            {/each}
-          </ul>
+          <RequirementsAndList items={components}>
+            {#snippet children({ item: componentChoices })}
+              {@const sortedChoices = sortComponentChoices(componentChoices)}
+              <RequirementsOrList
+                items={sortedChoices}
+                hideLabelWhenSingle={true}>
+                {#snippet children({ item: component })}
+                  <ThingLink
+                    id={component.id}
+                    count={component.count}
+                    type="item"
+                    showIcon={false} />
+                {/snippet}
+              </RequirementsOrList>
+            {/snippet}
+          </RequirementsAndList>
         </dd>
       {/if}
       {#if mending_method.turns_into}

--- a/src/types/ThingLink.svelte
+++ b/src/types/ThingLink.svelte
@@ -155,4 +155,8 @@ let iconItem = $derived(
   min-width: 0;
   word-break: break-word;
 }
+
+.item-link__count {
+  font-variant-caps: all-small-caps;
+}
 </style>

--- a/src/types/ToolQualityLink.svelte
+++ b/src/types/ToolQualityLink.svelte
@@ -11,5 +11,12 @@ interface Props {
 let { id, level = 1, count }: Props = $props();
 </script>
 
-{t("L")}{level}
-<ThingLink type="tool_quality" {id} showIcon={false} {count} />
+<ThingLink type="tool_quality" {id} showIcon={false} {count} /><span
+  class="level">{t("lvl")}{level}</span>
+
+<style>
+.level {
+  font-variant-caps: all-small-caps;
+  padding-left: 0.5em;
+}
+</style>

--- a/src/types/item/RequirementData.svelte
+++ b/src/types/item/RequirementData.svelte
@@ -5,6 +5,9 @@ import { getContext, untrack } from "svelte";
 import type { CBNData } from "../../data";
 
 import type { Recipe, RequirementData } from "../../types";
+import RequirementsAndList from "./RequirementsAndList.svelte";
+import { gameSingularName } from "../../i18n/game-locale";
+import RequirementsOrList from "./RequirementsOrList.svelte";
 import ThingLink from "../ThingLink.svelte";
 import RequirementDataTools from "./RequirementDataTools.svelte";
 
@@ -19,6 +22,39 @@ const requirement = untrack(() => sourceRequirement);
 const data = getContext<CBNData>("data");
 
 let { tools, qualities, components } = data.normalizeRequirements(requirement);
+
+type SortableComponentChoice = {
+  id: string;
+  count: number;
+  itemName: string;
+};
+
+function isSortableComponentChoice(component: {
+  id: string;
+  count: number;
+  itemName: string | null;
+}): component is SortableComponentChoice {
+  return component.itemName !== null;
+}
+
+function sortComponentChoices(
+  componentChoices: [string, number][],
+): { id: string; count: number }[] {
+  return componentChoices
+    .map(([id, count]) => ({
+      id,
+      count,
+      itemName: data.byIdMaybe("item", id)
+        ? gameSingularName(data.byId("item", id))
+        : null,
+    }))
+    .filter(isSortableComponentChoice)
+    .sort(
+      (a, b) =>
+        a.itemName.localeCompare(b.itemName) || a.id.localeCompare(b.id),
+    )
+    .map(({ id, count }) => ({ id, count }));
+}
 </script>
 
 {#if qualities?.length || tools?.length}
@@ -27,17 +63,19 @@ let { tools, qualities, components } = data.normalizeRequirements(requirement);
 {#if components.length}
   <dt>{t("Components", { _context })}</dt>
   <dd>
-    <ul>
-      {#each components as componentChoices}
-        <li>
-          {#each componentChoices
-            .map(([id, count]) => ({ id, count, item: data.byId("item", id) }))
-            .filter((c) => c.item) as { id, count }, i}
-            {#if i !== 0}{" OR "}{/if}
-            <ThingLink type="item" {id} {count} showIcon={false} />
-          {/each}
-        </li>
-      {/each}
-    </ul>
+    <RequirementsAndList items={components}>
+      {#snippet children({ item: componentChoices })}
+        {@const componentItems = sortComponentChoices(componentChoices)}
+        <RequirementsOrList items={componentItems}>
+          {#snippet children({ item: component })}
+            <ThingLink
+              type="item"
+              id={component.id}
+              count={component.count}
+              showIcon={false} />
+          {/snippet}
+        </RequirementsOrList>
+      {/snippet}
+    </RequirementsAndList>
   </dd>
 {/if}

--- a/src/types/item/RequirementDataTools.svelte
+++ b/src/types/item/RequirementDataTools.svelte
@@ -2,11 +2,13 @@
 import { t } from "@transifex/native";
 import { getContext, untrack } from "svelte";
 
+import RequirementsAndList from "./RequirementsAndList.svelte";
 import { CBNData } from "../../data";
 
 import type { Recipe, RequirementData } from "../../types";
-import ThingLink from "../ThingLink.svelte";
 import { gameSingularName } from "../../i18n/game-locale";
+import RequirementsOrList from "./RequirementsOrList.svelte";
+import ThingLink from "../ThingLink.svelte";
 import ToolQualityLink from "../ToolQualityLink.svelte";
 
 interface Props {
@@ -35,8 +37,26 @@ type ExactToolChoice = {
   count: number;
 };
 
+type RequirementChoiceRow =
+  | {
+      kind: "quality";
+      choices: { id: string; level?: number; amount?: number }[];
+    }
+  | {
+      kind: "tool";
+      choices: ExactToolChoice[];
+    };
+
 function exactToolChoiceName(choice: ExactToolChoice): string {
   return gameSingularName(data.byId(choice.type, choice.id));
+}
+
+function qualityChoiceName(choice: {
+  id: string;
+  level?: number;
+  amount?: number;
+}): string {
+  return gameSingularName(data.byId("tool_quality", choice.id));
 }
 
 function exactToolChoices(toolChoices: [string, number][]): ExactToolChoice[] {
@@ -60,46 +80,55 @@ function exactToolChoices(toolChoices: [string, number][]): ExactToolChoice[] {
 
   return exactChoices;
 }
+
+function sortedQualityChoices(
+  qualityChoices: { id: string; level?: number; amount?: number }[],
+): { id: string; level?: number; amount?: number }[] {
+  return [...qualityChoices].sort(
+    (a, b) =>
+      qualityChoiceName(a).localeCompare(qualityChoiceName(b)) ||
+      (a.level ?? 0) - (b.level ?? 0) ||
+      a.id.localeCompare(b.id),
+  );
+}
+
+let rows = $derived.by((): RequirementChoiceRow[] => [
+  ...(qualities ?? []).map((qualityChoices) => ({
+    kind: "quality" as const,
+    choices: sortedQualityChoices(qualityChoices),
+  })),
+  ...tools.map((toolChoices) => ({
+    kind: "tool" as const,
+    choices: exactToolChoices(toolChoices),
+  })),
+]);
 </script>
 
-{#if qualities?.length || tools.length}
+{#if rows.length}
   <dt>{t("Tools Required", { _context })}</dt>
   <dd>
-    <ul>
-      {#each qualities ?? [] as qualityChoices}
-        <li>
-          {#each qualityChoices as quality, i}
-            {#if i !== 0}{" OR "}{/if}
-            <ToolQualityLink
-              id={quality.id}
-              count={quality.amount}
-              level={quality.level} />
-          {/each}
-        </li>
-      {/each}
-      {#each tools as toolChoices}
-        {@const tc = exactToolChoices(toolChoices)}
-        <li>
-          {#each tc as exactChoice, i}
-            {#if i !== 0}{" OR "}{/if}
-            {@const charges = exactChoice.count}
-            {#if charges <= 0}
-              <ThingLink
-                type={exactChoice.type}
-                id={exactChoice.id}
-                showIcon={false} />
+    <RequirementsAndList items={rows}>
+      {#snippet children({ item: row })}
+        <RequirementsOrList items={row.choices} hideLabelWhenSingle={true}>
+          {#snippet children({ item: choice })}
+            {#if row.kind === "quality"}
+              <ToolQualityLink
+                id={choice.id}
+                count={choice.amount}
+                level={choice.level} />
             {:else}
-              <ThingLink
-                type={exactChoice.type}
-                id={exactChoice.id}
-                showIcon={false} />&nbsp;
-              {t("{charges} {charges, plural, =1 {charge} other {charges}}", {
-                charges,
-              })}
+              {@const charges = choice.count}
+              {#if charges <= 0}
+                <ThingLink type={choice.type} id={choice.id} showIcon={false} />
+              {:else}
+                <ThingLink type={choice.type} id={choice.id} showIcon={false} />
+                {charges}
+                {t("charges")}
+              {/if}
             {/if}
-          {/each}
-        </li>
-      {/each}
-    </ul>
+          {/snippet}
+        </RequirementsOrList>
+      {/snippet}
+    </RequirementsAndList>
   </dd>
 {/if}

--- a/src/types/item/RequirementDataTools.svelte
+++ b/src/types/item/RequirementDataTools.svelte
@@ -122,8 +122,9 @@ let rows = $derived.by((): RequirementChoiceRow[] => [
                 <ThingLink type={choice.type} id={choice.id} showIcon={false} />
               {:else}
                 <ThingLink type={choice.type} id={choice.id} showIcon={false} />
-                {charges}
-                {t("charges")}
+                {t("{charges} {charges, plural, =1 {charge} other {charges}}", {
+                  charges,
+                })}
               {/if}
             {/if}
           {/snippet}

--- a/src/types/item/RequirementsAndList.svelte
+++ b/src/types/item/RequirementsAndList.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+import { type Snippet } from "svelte";
+
+interface Props {
+  items: any[];
+  horizontal?: boolean;
+  children?: Snippet<[any]>;
+}
+
+let { items, horizontal = false, children }: Props = $props();
+</script>
+
+<div class="and-container">
+  <ul class="and-list" class:comma-separated={horizontal}>
+    {#each items as item}
+      <li>{@render children?.({ item })}</li>
+    {/each}
+  </ul>
+</div>
+
+<style>
+.and-container {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.3rem;
+}
+
+ul.and-list {
+  list-style-type: square;
+  padding-left: 0.5rem;
+  margin-left: 0.3rem;
+}
+
+ul.and-list.comma-separated {
+  padding-left: 0;
+  margin-left: 0;
+}
+ul.and-list li {
+  margin-left: 0;
+}
+</style>

--- a/src/types/item/RequirementsOrList.svelte
+++ b/src/types/item/RequirementsOrList.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+import { t } from "@transifex/native";
+import { type Snippet } from "svelte";
+
+const _context = "List of items";
+
+interface Props {
+  items: any[];
+  hideLabelWhenSingle?: boolean;
+  children?: Snippet<[any]>;
+}
+
+let { items, hideLabelWhenSingle = true, children }: Props = $props();
+
+// Compute visibility once
+let isSingleHidden = $derived(hideLabelWhenSingle && items.length === 1);
+</script>
+
+<div class="or-container" class:single={isSingleHidden}>
+  {#if !isSingleHidden}
+    <div class="or-label">
+      {t("Any of", { _context })}
+    </div>
+  {/if}
+  <ul class="or-list">
+    {#each items as item}
+      <li>{@render children?.({ item })}</li>
+    {/each}
+  </ul>
+</div>
+
+<style>
+.or-container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.or-label {
+  font-variant-caps: all-small-caps;
+  font-size: 0.9rem;
+  font-weight: bold;
+  color: var(--cata-color-gray);
+  letter-spacing: 0.05em;
+}
+
+ul.or-list {
+  border-left: 1px solid
+    color-mix(in srgb, var(--cata-color-cyan) 50%, transparent);
+  border-radius: 0 4px 4px 0;
+  padding: 0 0.4rem;
+  margin-left: 0.4rem;
+  list-style-type: none;
+}
+
+.single ul.or-list {
+  background-color: transparent;
+  border-left: none;
+  padding: 0;
+  margin: 0;
+}
+</style>


### PR DESCRIPTION
## Summary
- Extract shared requirement-list shells for construction, faults, and item requirements
- Align tool-quality and thing-link rendering with the new list structure
- Tweak list styling in `design.css` to keep the nested layout readable

## Testing
- Not run (not requested)